### PR TITLE
add talks

### DIFF
--- a/src/components/ListView.svelte
+++ b/src/components/ListView.svelte
@@ -1,7 +1,7 @@
 <script context='module' lang='ts'>
 	export type Item = {
 		title: string;
-		link: string;
+		link?: string;
 		slug: string;
 		lang?: string;
 		external?: boolean;
@@ -25,7 +25,7 @@
 </script>
 <div mxa px-10>
 	{#each items as item, count (item.slug)}
-		{@const external = item.link.startsWith('http')}
+		{@const external = typeof item.link === 'string' && item?.link.startsWith('http')}
 		<div
 			style:--stagger={count}
 			style:--start='300ms'
@@ -33,18 +33,24 @@
 			my-2
 			sliding-animation-delay-base
 		>
-			<a
-				class='group'
-				fyc
-				gap-3
-				href={item.link}
-				mr-5
-				op-card
-				target={external ? '_blank' : ''}
-				transition-base
-			>
-				{@render itemView(item)}
-			</a>
+			{#if item.link != null}
+				<a
+					class='group'
+					fyc
+					gap-3
+					href={item.link}
+					mr-5
+					op-card
+					target={external ? '_blank' : ''}
+					transition-base
+				>
+					{@render itemView(item)}
+				</a>
+			{:else}
+				<div class='group' fyc gap-3 mr-5 op-card transition-base>
+					{@render itemView(item)}
+				</div>
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -7,6 +7,7 @@
 	const LINKS = [
 		{ name: 'projects', href: '/projects' },
 		{ name: 'blog', href: '/blog' },
+		{ name: 'talks', href: '/talks' },
 		{ name: 'cv', href: subdomain('/cv'), icon: 'i-line-md:download-outline' },
 	] as const satisfies { href: string; name: string; icon?: string }[];
 </script>

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -6,8 +6,8 @@
 
 	const LINKS = [
 		{ name: 'projects', href: '/projects' },
-		{ name: 'blog', href: '/blog' },
 		{ name: 'talks', href: '/talks' },
+		{ name: 'blog', href: '/blog' },
 		{ name: 'cv', href: subdomain('/cv'), icon: 'i-line-md:download-outline' },
 	] as const satisfies { href: string; name: string; icon?: string }[];
 </script>

--- a/src/routes/talks/+page.server.ts
+++ b/src/routes/talks/+page.server.ts
@@ -1,0 +1,50 @@
+import { error } from '@sveltejs/kit';
+import type { tags } from 'typia';
+import typia from 'typia';
+import { parseJSON } from 'date-fns';
+import type { PageServerLoad } from './$types';
+import { formatDate } from '$lib/util';
+import { slugify } from '$lib/slugify.server';
+
+export type Talk = {
+	title: string;
+	date: string;
+	event: string;
+	eventLink?: string & tags.Format<'url'>;
+	videoLink?: string & tags.Format<'url'>;
+	content: string;
+	urls: string[];
+};
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	const res = await fetch('https://talks.ryoppippi.com/talks.json');
+	if (!res.ok) {
+		return error(res.status, 'Failed to fetch talks');
+	}
+
+	const talks = await res.json();
+
+	typia.assertGuard<Talk[]>(talks);
+
+	const talkWithParsedDate = talks.map(talk => ({
+		...talk,
+		date: formatDate(parseJSON(talk.date)),
+		slug: slugify(talk.title + talk.date + talk.event),
+		link: talk.urls[0],
+	}));
+
+	/* split by year */
+	const talksByYear: Record<string, Talk[]> = {};
+	talkWithParsedDate.forEach((talk) => {
+		const year = new Date(talk.date).getFullYear().toString();
+		if (talksByYear[year] == null) {
+			talksByYear[year] = [];
+		}
+		talksByYear[year].push(talk);
+	});
+
+	return {
+		talks: talksByYear,
+		title: 'talks',
+	};
+};

--- a/src/routes/talks/+page.server.ts
+++ b/src/routes/talks/+page.server.ts
@@ -30,12 +30,19 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		...talk,
 		date: formatDate(parseJSON(talk.date)),
 		slug: slugify(talk.title + talk.date + talk.event),
-		link: talk.urls[0],
+		link: null,
 	}));
+
+	/* filter the talks dosn't happen yet */
+	const today = new Date();
+	const talksHappened = talkWithParsedDate.filter((talk) => {
+		const talkDate = new Date(talk.date);
+		return talkDate < today;
+	});
 
 	/* split by year */
 	const talksByYear: Record<string, Talk[]> = {};
-	talkWithParsedDate.forEach((talk) => {
+	talksHappened.forEach((talk) => {
 		const year = new Date(talk.date).getFullYear().toString();
 		if (talksByYear[year] == null) {
 			talksByYear[year] = [];

--- a/src/routes/talks/+page.svelte
+++ b/src/routes/talks/+page.svelte
@@ -1,0 +1,38 @@
+<script lang='ts'>
+	import { type Item as ListItem } from '$components/ListView.svelte';
+
+	const { data } = $props();
+	const { talks } = data;
+
+	type Talk = typeof talks[string][0];
+
+	$inspect({ talks });
+</script>
+
+{#snippet itemView(_item: ListItem)}
+	{@const item = _item as unknown as Talk}
+	<div>
+		<h3 text-xl>{item.title}</h3>
+		<p op50>
+			{item.event}
+			<span op80 pl-2 text-sm truncate>{item.date}</span>
+		</p>
+	</div>
+{/snippet}
+
+{#each Object.entries(talks).sort(([a], [b]) => Number(b) - Number(a)) as [year, items], count (year)}
+	<LargeTitle title={year} />
+
+	<div
+		style:--stagger={count}
+		animate-delay-base
+		no-underline
+		sliding-animation='~ delay-base'
+	>
+		<ListView
+			animation={false}
+			{itemView}
+			items={items as unknown as ListItem[]}
+		/>
+	</div>
+{/each}

--- a/src/routes/talks/+page.svelte
+++ b/src/routes/talks/+page.svelte
@@ -11,12 +11,17 @@
 
 {#snippet itemView(_item: ListItem)}
 	{@const item = _item as unknown as Talk}
-	<div>
-		<h3 text-xl>{item.title}</h3>
+	<div mt-5>
+		<h3 text-xl><a href={item.urls.at(0)}>{item.title}</a></h3>
 		<p op50>
-			{item.event}
+			<a href={item.eventLink}>{item.event}</a>
 			<span op80 pl-2 text-sm truncate>{item.date}</span>
 		</p>
+		{#if item.videoLink}
+			<p op50>
+				<a href={item.videoLink}>Watch the video</a>
+			</p>
+		{/if}
 	</div>
 {/snippet}
 
@@ -36,3 +41,9 @@
 		/>
 	</div>
 {/each}
+
+<style>
+a {
+	--at-apply: hover:underline;
+}
+</style>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new navigation link for "Talks" in the navigation menu.
	- Introduced a dedicated page to display a list of talks, organized by year.
	- Implemented server-side functionality to fetch and process talk data from an external API.
	- Enhanced item rendering in the list view to gracefully handle items without links.

- **Documentation**
	- Updated types and structures for better data representation and type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->