### PR TITLE
feat(projects): add svelte-fancy-darkmode to OSS projects list

### DIFF
--- a/src/contents/projects/oss/list.json
+++ b/src/contents/projects/oss/list.json
@@ -41,6 +41,10 @@
 		{
 			"name": "svelte-preprocess-import-css",
 			"icon": "i-ph:palette-light"
+		},
+		{
+			"name": "svelte-fancy-darkmode",
+			"icon": "i-ph:moon-stars-light"
 		}
 	],
 	"TypeScript Ecosystem": [


### PR DESCRIPTION
Added a new project "svelte-fancy-darkmode" with its icon to the OSS
projects list in the JSON file.
