### PR TITLE
feat: add new-post script to create blog post templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"private": true,
 	"packageManager": "pnpm@10.4.1",
 	"scripts": {
+		"new": "./scripts/new-post.js",
 		"dev": "vite dev",
 		"build": "vite build",
 		"postbuild": "nlx svelte-sitemap --domain https://ryoppippi.com",
@@ -74,7 +75,9 @@
 		"@unocss/reset": "^66.0.0",
 		"@unplugin/macros": "npm:@jsr/unplugin__macros@^0.16.0",
 		"buffer": "^6.0.3",
+		"consola": "^3.4.0",
 		"date-fns": "^4.1.0",
+		"dax-sh": "^0.42.0",
 		"diacritics": "^1.3.0",
 		"eslint": "^9.20.1",
 		"eslint-plugin-format": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,9 +173,15 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      consola:
+        specifier: ^3.4.0
+        version: 3.4.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dax-sh:
+        specifier: ^0.42.0
+        version: 0.42.0
       diacritics:
         specifier: ^1.3.0
         version: 1.3.0
@@ -421,6 +427,12 @@ packages:
 
   '@clack/prompts@0.9.1':
     resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
+
+  '@deno/shim-deno-test@0.5.0':
+    resolution: {integrity: sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==}
+
+  '@deno/shim-deno@0.19.2':
+    resolution: {integrity: sha512-q3VTHl44ad8T2Tw2SpeAvghdGOjlnLPDNO2cpOxwMrBE/PVas6geWpbpIgrM+czOCH0yejp0yi8OaTuB+NU40Q==}
 
   '@dprint/formatter@0.3.0':
     resolution: {integrity: sha512-N9fxCxbaBOrDkteSOzaCqwWjso5iAe+WJPsHC021JfHNj2ThInPNEF13ORDKta3llq5D1TlclODCvOvipH7bWQ==}
@@ -2139,8 +2151,8 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
-  consola@3.2.3:
-    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+  consola@3.4.0:
+    resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   cookie@0.6.0:
@@ -2193,6 +2205,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dax-sh@0.42.0:
+    resolution: {integrity: sha512-VxTiRJPYJWRw7XIP67w+iFx0DETNaYYYacWBm8c1zibHsliPXgzVAw7NiGTRum2+KIAEA1MBkiP1308NQoIgUA==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -4115,6 +4130,9 @@ packages:
   unconfig@0.5.5:
     resolution: {integrity: sha512-VQZ5PT9HDX+qag0XdgQi8tJepPhXiR/yVOkn707gJDKo31lGjRilPREiQJ9Z6zd/Ugpv6ZvO5VxVIcatldYcNQ==}
 
+  undici-types@5.28.4:
+    resolution: {integrity: sha512-3OeMF5Lyowe8VW0skf5qaIE7Or3yS9LS7fvMUI0gg4YxpIBVg0L8BxCmROw2CcYhSkpR68Epz7CGc8MPj94Uww==}
+
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
@@ -4662,6 +4680,13 @@ snapshots:
       '@clack/core': 0.4.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@deno/shim-deno-test@0.5.0': {}
+
+  '@deno/shim-deno@0.19.2':
+    dependencies:
+      '@deno/shim-deno-test': 0.5.0
+      which: 4.0.0
 
   '@dprint/formatter@0.3.0': {}
 
@@ -5252,7 +5277,7 @@ snapshots:
   '@jsr/ryoppippi__unplugin-typia@1.2.0(@samchon/openapi@2.4.0)(@types/node@22.13.4)(jiti@1.21.7)(rollup@4.34.6)(tsx@4.19.2)(yaml@2.6.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.6)
-      consola: 3.2.3
+      consola: 3.4.0
       defu: 6.1.4
       diff-match-patch: 1.0.5
       find-cache-dir: 5.0.0
@@ -5919,7 +5944,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       colorette: 2.0.20
-      consola: 3.2.3
+      consola: 3.4.0
       magic-string: 0.30.17
       pathe: 1.1.2
       perfect-debounce: 1.0.0
@@ -6381,7 +6406,7 @@ snapshots:
 
   confbox@0.1.8: {}
 
-  consola@3.2.3: {}
+  consola@3.4.0: {}
 
   cookie@0.6.0: {}
 
@@ -6430,6 +6455,11 @@ snapshots:
       whatwg-url: 14.0.0
 
   date-fns@4.1.0: {}
+
+  dax-sh@0.42.0:
+    dependencies:
+      '@deno/shim-deno': 0.19.2
+      undici-types: 5.28.4
 
   debug@3.2.7:
     dependencies:
@@ -8800,6 +8830,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  undici-types@5.28.4: {}
+
   undici-types@6.20.0: {}
 
   unicorn-magic@0.1.0: {}
@@ -8974,7 +9006,7 @@ snapshots:
 
   vite-plugin-favicons@0.1.5(typescript@5.7.3)(vite@5.4.14(@types/node@22.13.4)):
     dependencies:
-      consola: 3.2.3
+      consola: 3.4.0
       favicons: 7.2.0
       fs-extra: 11.3.0
       pathe: 1.1.2

--- a/scripts/new-post.js
+++ b/scripts/new-post.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+import { consola } from 'consola';
+import * as d from 'date-fns';
+import { $ } from 'dax-sh';
+import matter from 'gray-matter';
+
+const title = await consola.prompt(
+	'Enter the title of the post',
+	{
+		type: 'text',
+		required: true,
+	},
+);
+if (!title) {
+	consola.error('Title is required');
+	process.exit(1);
+}
+
+const date = d.format(new Date(), 'yyyy-MM-dd');
+const lang = await consola.prompt(
+	'Enter the language of the post',
+	{
+		type: 'select',
+		options: ['ja', 'en'],
+		initial: 'ja',
+	},
+);
+
+consola.start('Creating project...');
+
+const blogDir = $.path(import.meta.dirname).join(`../src/contents/blog/`);
+const location = $.path(blogDir).join(`${date}-${title.toLowerCase().replace(/ /g, '-')}.md`);
+const frontMatter = matter.stringify('', {
+	title,
+	date,
+	isPublished: false,
+	lang,
+});
+
+await $`touch ${location}`;
+await $`echo ${frontMatter} > ${location}`;
+consola.success(`Post created at ${location}`);

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -128,6 +128,7 @@ const config = {
 		typescript: {
 			config(config) {
 				config.include.push(path.join(import.meta.dirname, 'uno.config.ts'));
+				config.include.push(path.join(import.meta.dirname, 'scripts/**/*.ts'));
 			},
 		},
 		alias: {


### PR DESCRIPTION
Add a command line script that generates new blog post markdown files with proper frontmatter. The script prompts for title and language, then creates a file with the current date and slugified title.