### PR TITLE
feat: return plain markdown if `.md` extension added to the end of blog slug

### DIFF
--- a/src/routes/blog/[slug].md/+server.ts
+++ b/src/routes/blog/[slug].md/+server.ts
@@ -1,0 +1,26 @@
+import type { Metadata } from '$contents/blog/types';
+import type { MarkdownImport } from '../../../markdown';
+import type { RequestHandler } from './$types';
+import { error } from '@sveltejs/kit';
+
+export const prerender = true;
+
+export const GET: RequestHandler = async ({ params: { slug } }) => {
+	try {
+		// Verify the blog post exists by importing it
+		await import(`../../../contents/blog/${slug}.md`) as unknown as MarkdownImport<Metadata>;
+
+		// Import the raw markdown content
+		const rawMd = await import(`../../../contents/blog/${slug}.md?raw`) as { default: string };
+
+		return new Response(rawMd.default, {
+			headers: {
+				'Content-Type': 'text/plain; charset=utf-8'
+			}
+		});
+	}
+	catch (e) {
+		console.error(e);
+		error(404, 'Post not found');
+	}
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fetching raw markdown content of individual blog posts via a GET request to the blog post route.
  - Blog post routes now return a 404 error if the requested post does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->