### PR TITLE
refactor: remove ufo dependency and use native URL API

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
 		"type-fest": "^4.41.0",
 		"typescript": "^5.9.2",
 		"typescript-svelte-plugin": "^0.3.49",
-		"ufo": "^1.6.1",
 		"unocss": "^66.4.0",
 		"unocss-preset-fluid": "^1.0.2",
 		"unocss-transformer-alias": "^0.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,6 @@ importers:
       typescript-svelte-plugin:
         specifier: ^0.3.49
         version: 0.3.49(svelte@5.37.3)(typescript@5.9.2)
-      ufo:
-        specifier: ^1.6.1
-        version: 1.6.1
       unocss:
         specifier: ^66.4.0
         version: 66.4.1(postcss@8.5.6)(rolldown-vite@7.1.0(@types/node@24.1.0)(esbuild@0.25.4)(jiti@2.4.2)(yaml@2.8.0))

--- a/src/components/GitHubNav.svelte
+++ b/src/components/GitHubNav.svelte
@@ -1,6 +1,5 @@
 <script lang='ts'>
 	import { PUBLIC_ORIGIN } from '$env/static/public';
-	import * as ufo from 'ufo';
 </script>
 
 {#snippet link(
@@ -14,7 +13,7 @@
 		fcol-md-row
 		fyc
 		gap-1
-		href={ufo.joinURL(PUBLIC_ORIGIN, _subdomain)}
+		href={new URL(_subdomain, PUBLIC_ORIGIN).toString()}
 		target='_blank'
 	>
 		<!-- svelte-ignore element_invalid_self_closing_tag -->

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -3,7 +3,6 @@
 	import { page } from '$app/state';
 	import { PUBLIC_ORIGIN } from '$env/static/public';
 	import * as DarkMode from 'svelte-fancy-darkmode';
-	import * as ufo from 'ufo';
 	import MoonToSunny from '~icons/line-md/moon-filled-to-sunny-filled-loop-transition';
 	import SunnyToMoon from '~icons/line-md/sunny-filled-loop-to-moon-filled-transition';
 
@@ -13,7 +12,7 @@
 		{ name: 'blog', href: resolve('/blog') },
 		{
 			name: 'cv',
-			href: ufo.joinURL(PUBLIC_ORIGIN, '/cv'),
+			href: new URL('/cv', PUBLIC_ORIGIN).toString(),
 			icon: 'i-line-md:download-outline',
 		},
 	] as const satisfies { href: string; name: string; icon?: string }[];

--- a/src/components/Social.svelte
+++ b/src/components/Social.svelte
@@ -1,6 +1,5 @@
 <script lang='ts'>
 	import { PUBLIC_ORIGIN } from '$env/static/public';
-	import * as ufo from 'ufo';
 
 	const { size = 4.5 } = $props();
 
@@ -14,7 +13,7 @@
 		{ class: 'i-ri:youtube-line', url: '/youtube' },
 	] as const)
 		.map(({ url, ...rest }) => ({
-			url: ufo.joinURL(PUBLIC_ORIGIN, url),
+			url: new URL(url, PUBLIC_ORIGIN).toString(),
 			...rest,
 		}));
 </script>
@@ -26,7 +25,7 @@
 	grid-cols='3 sm:7'
 >
 	{#each ICONS as { class: _class, url } (url)}
-		{@const { pathname } = ufo.parseURL(url)}
+		{@const { pathname } = new URL(url)}
 		{@const path = pathname.replace('/', '')}
 		<div
 			cursor-pointer

--- a/src/contents/projects/oss/index.ts
+++ b/src/contents/projects/oss/index.ts
@@ -1,6 +1,5 @@
 import type { Entries } from 'type-fest';
 import type { Project } from './types.js';
-import { joinURL } from 'ufo';
 import _ossProjects from './list.json';
 import { OssProjects, ParsedProject, ProjectsByGenre, UnghRepo, URL } from './types.js';
 
@@ -16,7 +15,7 @@ async function processProject(
 ) {
 	// Ensure project has a link
 	if (project.link == null) {
-		project.link = URL.assert(joinURL(GITHUB_URL, GITHUB_USERNAME, project.name));
+		project.link = URL.assert(`${GITHUB_URL}/${GITHUB_USERNAME}/${project.name}`);
 	}
 
 	const link = URL.assert(project.link);
@@ -24,7 +23,7 @@ async function processProject(
 	// Fetch repo info if description is missing or null
 	if (project.description == null) {
 		try {
-			const url = joinURL(UNGH_URL, 'repos', GITHUB_USERNAME, project.name);
+			const url = `${UNGH_URL}/repos/${GITHUB_USERNAME}/${project.name}`;
 			const res = await fetch(url);
 			if (!res.ok) {
 				throw new Error(`Failed to fetch repo info for ${project.name}: ${res.statusText}`);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,6 @@
 	import ryoppippi from '$lib/assets/ryoppippi.jpg';
 	import { Header as DarkModeHeader } from 'svelte-fancy-darkmode';
 	import { MetaTags } from 'svelte-meta-tags';
-	import * as ufo from 'ufo';
 	import faviconLinks from 'virtual:favicons';
 	import 'uno.css';
 	import '@unocss/reset/tailwind.css';
@@ -30,7 +29,7 @@
 
 	const title = $derived(page.data.title ?? 'home');
 	const description = `Portfolio of @ryoppippi`;
-	const ogImage = ufo.joinURL(PUBLIC_ORIGIN, ryoppippi);
+	const ogImage = new URL(ryoppippi, PUBLIC_ORIGIN).toString();
 </script>
 
 <DarkModeHeader themeColors={{ dark: '#121212', light: '#ffffff' }} />
@@ -61,7 +60,7 @@
 	}}
 	{description}
 	openGraph={{
-		url: ufo.joinURL(PUBLIC_ORIGIN, page.url.pathname),
+		url: new URL(page.url.pathname, PUBLIC_ORIGIN).toString(),
 		type: 'website',
 		title,
 		description,

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -4,7 +4,6 @@
 	import LargeTitle from '$components/LargeTitle.svelte';
 	import { PUBLIC_ORIGIN } from '$env/static/public';
 	import { formatDate } from '$lib/util';
-	import * as ufo from 'ufo';
 	import '@shikijs/twoslash/style-rich.css';
 	import 'markdown-it-github-alerts/styles/github-colors-light.css';
 	import 'markdown-it-github-alerts/styles/github-colors-dark-class.css';
@@ -17,7 +16,7 @@
 	const { data } = $props();
 	const { metadata, Markdown } = data;
 
-	const url = ufo.joinURL(PUBLIC_ORIGIN, page.url.pathname);
+	const url = new URL(page.url.pathname, PUBLIC_ORIGIN).toString();
 	const shareText = (account: string) => encodeURIComponent(`Reading ${account}\'s ${url}\n\nI think...`);
 	const tweetUrl = `https://twitter.com/intent/tweet?text=${shareText('@ryoppippi')}`;
 	const bskyUrl = `https://bsky.app/intent/compose?text=${shareText('@ryoppippi.com')}`;

--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -3,12 +3,11 @@ import { asset, resolve } from '$app/paths';
 import { blogPosts } from '$contents/blog' with { type: 'macro' };
 import { PUBLIC_ORIGIN } from '$env/static/public';
 import { Feed } from 'feed';
-import * as ufo from 'ufo';
 
 export const prerender = true;
 
 export const GET = (async () => {
-	const favicon = ufo.joinURL(PUBLIC_ORIGIN, asset('/ryoppippi.jpg'));
+	const favicon = new URL(asset('/ryoppippi.jpg'), PUBLIC_ORIGIN).toString();
 
 	const feed = new Feed({
 		title: `blog | ryoppippi.com`,
@@ -20,7 +19,7 @@ export const GET = (async () => {
 		favicon,
 		copyright: 'CC BY-NC-SA 4.0 2022-PRESENT © ryoppippi',
 		feedLinks: {
-			rss: ufo.joinURL(PUBLIC_ORIGIN, resolve('/feed.xml')),
+			rss: new URL(resolve('/feed.xml'), PUBLIC_ORIGIN).toString(),
 		},
 	});
 
@@ -36,7 +35,7 @@ export const GET = (async () => {
 		}
 
 		feed.addItem({
-			link: ufo.joinURL(PUBLIC_ORIGIN, resolve('/blog/[slug]', { slug })),
+			link: new URL(resolve('/blog/[slug]', { slug }), PUBLIC_ORIGIN).toString(),
 			date: new Date(post.pubDate),
 			title: post.title,
 			description: `${post.title} | ${post.readingTime.text}`,


### PR DESCRIPTION
## Summary
- Replaced all \`ufo.joinURL()\` calls with native \`new URL().toString()\` 
- Replaced \`ufo.parseURL()\` with native \`new URL()\` for URL parsing
- Removed ufo dependency from package.json

## Changes by file
- **Layout & Pages**: Updated `+layout.svelte` and blog page to use native URL API
- **Components**: Refactored `Nav`, `Social`, and `GitHubNav` components
- **Server**: Updated `feed.xml` server endpoint
- **OSS Projects**: Simplified URL construction using template literals
- **Dependencies**: Removed ufo from devDependencies

## Test plan
- [x] Type checking passes (\`pnpm check\`)
- [x] Linting passes (\`pnpm lint\`)
- [ ] Manual testing of all affected pages and components
- [ ] Verify RSS feed generation works correctly
- [ ] Check all social links and navigation links work properly