### PR TITLE
fix: improve site accessibility

### DIFF
--- a/src/components/CheckButton.svelte
+++ b/src/components/CheckButton.svelte
@@ -15,6 +15,7 @@
 
 <button
 	{...rest}
+	aria-pressed={checked}
 	fyc='~'
 	gap-1='~'
 	op30='~'
@@ -27,6 +28,7 @@
 			'i-carbon-checkbox': !checked,
 			'i-carbon-checkbox-checked': checked,
 		}}
+		aria-hidden='true'
 	/>
 	{text}
 </button>

--- a/src/components/GitHubNav.svelte
+++ b/src/components/GitHubNav.svelte
@@ -15,10 +15,11 @@
 		fyc
 		gap-1
 		href={ufo.joinURL(PUBLIC_ORIGIN, _subdomain)}
+		rel='noopener noreferrer'
 		target='_blank'
 	>
 		<!-- svelte-ignore element_invalid_self_closing_tag -->
-		<span class={icon} /> {name}
+		<span class={icon} aria-hidden='true' /> {name}
 	</a>
 {/snippet}
 

--- a/src/components/LargeTitle.svelte
+++ b/src/components/LargeTitle.svelte
@@ -1,19 +1,24 @@
 <script lang='ts'>
 	type Props = {
 		title: string;
+		level?: 1 | 2;
 		viewTransitionName?: string;
 		selectDisabled?: boolean;
 		opacity?: boolean;
 	};
 	const {
 		title,
+		level = 1,
 		viewTransitionName,
 		selectDisabled = false,
 		opacity = true,
 	}: Props = $props();
+
+	const tag = $derived(`h${level}` as const);
 </script>
 
-<h1
+<svelte:element
+	this={tag}
 	style:view-transition-name={viewTransitionName}
 	class={{ 'op-35 dark:op-20': opacity, 'select-none': selectDisabled }}
 	f-text-32-64
@@ -24,4 +29,4 @@
 	text-transparent
 >
 	{title}
-</h1>
+</svelte:element>

--- a/src/components/ListView.svelte
+++ b/src/components/ListView.svelte
@@ -33,7 +33,8 @@
 					href={item.link}
 					mr-5
 					op-card
-					target={external ? '_blank' : ''}
+					rel={external ? 'noopener noreferrer' : undefined}
+					target={external ? '_blank' : undefined}
 					transition-base
 				>
 					{@render itemView(item)}

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -64,6 +64,7 @@
 		</a>
 	</div>
 	<nav
+		aria-label='Primary navigation'
 		col-span-2
 		flex='wrap  '
 		font-bold
@@ -82,13 +83,14 @@
 					block
 					{href}
 					px-0
+					rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
 					relative
 					target={href.startsWith('http') ? '_blank' : undefined}
 				>
 					<div fyc>
 						{name}
 						<!-- svelte-ignore element_invalid_self_closing_tag -->
-						{#if icon != null} <span class={icon} /> {/if}
+						{#if icon != null} <span class={icon} aria-hidden='true' /> {/if}
 					</div>
 					{@render underline(isPath, false)}
 				</a>
@@ -106,21 +108,25 @@
 			</DarkMode.ToggleButton>
 			<a
 				class='i-line-md:rss'
+				aria-label='RSS feed'
 				fyc
 				href={resolve('/feed.xml')}
 				mya
+				rel='noopener noreferrer'
 				target='_blank'
 			>
-				source code
+				RSS feed
 			</a>
 			<a
 				class='i-teenyicons:github-solid'
+				aria-label='Source code on GitHub'
 				fyc
 				href='https://github.com/ryoppippi/ryoppippi.com'
 				mya
+				rel='noopener noreferrer'
 				target='_blank'
 			>
-				source code
+				Source code
 			</a>
 		</div>
 	</nav>

--- a/src/components/OssProjectCard.svelte
+++ b/src/components/OssProjectCard.svelte
@@ -14,6 +14,7 @@
 	max-w-full
 	no-underline
 	op-card
+	rel='noopener noreferrer'
 	select-none
 	target='_blank'
 	transition-base
@@ -21,6 +22,7 @@
 	<!-- svelte-ignore element_invalid_self_closing_tag -->
 	<div
 		style:view-transition-name={slug}
+		aria-hidden='true'
 		gcc
 	>
 		<div class={icon} op50 text-3xl />

--- a/src/components/Profile.svelte
+++ b/src/components/Profile.svelte
@@ -6,7 +6,7 @@
 <div>
 	<Image
 		class='mx-auto aspect-square w-1/2 rounded-full object-contain view-transition-name---profile md:size-64'
-		alt='profile'
+		alt='ryoppippi profile photo'
 		fetchpriority='high'
 		loading='eager'
 		src={asset('/ryoppippi.avif')}

--- a/src/components/ShowcaseCard.svelte
+++ b/src/components/ShowcaseCard.svelte
@@ -23,7 +23,12 @@
 	target={project.link.startsWith('http') ? '_blank' : '_self'}
 	transition-base
 >
-	<a href={project.link} no-underline target={project.link.startsWith('http') ? '_blank' : '_self'}>
+	<a
+		href={project.link}
+		no-underline
+		rel={project.link.startsWith('http') ? 'noopener noreferrer' : undefined}
+		target={project.link.startsWith('http') ? '_blank' : '_self'}
+	>
 		{#if project.image != null}
 			<Image
 				alt={project.title}
@@ -42,10 +47,14 @@
 		pb3
 		transition-base
 	>
-		<a href={project.link}>
-			<h3 hover-underline text-2xl>
+		<a
+			href={project.link}
+			rel={project.link.startsWith('http') ? 'noopener noreferrer' : undefined}
+			target={project.link.startsWith('http') ? '_blank' : undefined}
+		>
+			<h2 hover-underline text-2xl>
 				{project.title}
-			</h3>
+			</h2>
 		</a>
 		<div prose='base sm'><Content /></div>
 		{#if project.pubDate}

--- a/src/components/Social.svelte
+++ b/src/components/Social.svelte
@@ -5,12 +5,12 @@
 	const { size = 4.5 } = $props();
 
 	const ICONS = ([
-		{ class: 'i-line-md:github-loop', url: '/github' },
-		{ class: 'i-ph-git-pull-request-duotone', url: '/pr' },
-		{ class: 'i-line-md:linkedin', url: '/linkedin' },
-		{ class: 'i-line-md:twitter', url: '/twitter' },
-		{ class: 'i-simple-icons:bluesky', url: '/bsky' },
-		{ class: 'i-ri:youtube-line', url: '/youtube' },
+		{ class: 'i-line-md:github-loop', label: 'GitHub profile', url: '/github' },
+		{ class: 'i-ph-git-pull-request-duotone', label: 'Recent pull requests', url: '/pr' },
+		{ class: 'i-line-md:linkedin', label: 'LinkedIn profile', url: '/linkedin' },
+		{ class: 'i-line-md:twitter', label: 'Twitter profile', url: '/twitter' },
+		{ class: 'i-simple-icons:bluesky', label: 'Bluesky profile', url: '/bsky' },
+		{ class: 'i-ri:youtube-line', label: 'YouTube channel', url: '/youtube' },
 	] as const)
 		.map(({ url, ...rest }) => ({
 			url: ufo.joinURL(PUBLIC_ORIGIN, url),
@@ -26,20 +26,18 @@
 	grid-cols-3
 	sm:grid-cols='[repeat(var(--cols),minmax(0,1fr))]'
 >
-	{#each ICONS as { class: _class, url } (url)}
-		{@const { pathname } = ufo.parseURL(url)}
-		{@const path = pathname.replace('/', '')}
+	{#each ICONS as { class: _class, label, url } (url)}
 		<div
-			cursor-pointer
 			hover='scale-110 shadow-xl z-10 bg-[#88888811] op100'
 			op-card
 			transition-base
 		>
-			<a aria-label="link to ryoppippi's {path}" href={url} rel='noopener noreferrer' target='_blank'>
+			<a aria-label={label} href={url} rel='noopener noreferrer' target='_blank'>
 				<!-- svelte-ignore element_invalid_self_closing_tag -->
 				<div
 					style:--size='{size}vh'
 					class={_class}
+					aria-hidden='true'
 					text-size='[--size]'
 				/>
 			</a>

--- a/src/components/Tweet.svelte
+++ b/src/components/Tweet.svelte
@@ -7,4 +7,12 @@
 	const { id }: Props = $props();
 </script>
 
-<st.Tweet tweet={await getTweet({ id })} />
+<svelte:boundary>
+	{#await getTweet({ id }) then tweet}
+		<st.Tweet {tweet} />
+	{/await}
+
+	{#snippet failed()}
+		<a href='https://x.com/i/web/status/{id}' rel='noopener noreferrer' target='_blank'>Tweet {id}</a>
+	{/snippet}
+</svelte:boundary>

--- a/src/markdown/markdown.ts
+++ b/src/markdown/markdown.ts
@@ -49,7 +49,7 @@ md.use(anchor, {
 	slugify,
 	permalink: anchor.permalink.linkInsideHeader({
 		symbol: '#',
-		renderAttrs: () => ({ 'aria-hidden': 'true' }),
+		renderAttrs: () => ({ 'aria-hidden': 'true', 'tabindex': '-1' }),
 	}),
 });
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -95,12 +95,16 @@
 	{/each}
 </svelte:head>
 
-<main max-w-4xl mxa my3 px-8 un-dark>
+<a class='skip-link' href='#main-content'>Skip to content</a>
+
+<div max-w-4xl mxa my3 px-8 un-dark>
 	<Nav />
-	{#key page.url}
-		{@render children()}
-	{/key}
-</main>
+	<main id='main-content' tabindex='-1'>
+		{#key page.url}
+			{@render children()}
+		{/key}
+	</main>
+</div>
 
 <style>
 
@@ -114,6 +118,10 @@
 	}
 	@view-transition {
 		navigation: auto;
+	}
+
+	.skip-link {
+		--uno: sr-only focus:(not-sr-only fixed left-4 top-4 z-50 rounded bg-white px-4 py-2 text-text-800 shadow-lg outline-2 outline-accent-100 dark:bg-bg-100 dark:text-text-100);
 	}
 }
 </style>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -18,6 +18,8 @@
 	};
 </script>
 
+<h1 class='sr-only'>Blog</h1>
+
 {#snippet itemView(_item: Item)}
 	{@const item = _item as typeof data.posts[0]}
 	{@const filterByEnglish = !(isOnlyEnglish && item.lang !== 'en')}
@@ -34,6 +36,7 @@
 							'i-quill-link-out': item.external, // default for external links
 						},
 					]}
+					aria-hidden='true'
 				/>
 			</span>
 			<p

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -48,7 +48,7 @@
 			title={metadata.title}
 			viewTransitionName='blog-{metadata.slug}'
 		/>
-		<p text-text-400>{formatDate(new Date(metadata.pubDate))} ・ {metadata.readingTime.text} ・ <a href={mdUrl} op70 target='_blank' hover:op100><IconMarkdown class='inline align-middle' /></a></p>
+		<p text-text-400>{formatDate(new Date(metadata.pubDate))} ・ {metadata.readingTime.text} ・ <a class='hover:op100' aria-label='Markdown source' href={mdUrl} op70 rel='noopener noreferrer' target='_blank'><IconMarkdown class='inline align-middle' aria-hidden='true' /></a></p>
 	</hgroup>
 
 	<div p2>
@@ -60,13 +60,13 @@
 	</article>
 	<div op50 pb-8>
 		<span op70>comment on</span>
-		<a href={bskyUrl} target='_blank'>bluesky</a>
+		<a href={bskyUrl} rel='noopener noreferrer' target='_blank'>bluesky</a>
 		<span op35> / </span>
-		<a href={tweetUrl} target='_blank'>twitter</a>
+		<a href={tweetUrl} rel='noopener noreferrer' target='_blank'>twitter</a>
 	</div>
 
 	<div op50 pb-8>
-		<a href='https://creativecommons.org/licenses/by-nc-sa/4.0/' target='_blank'>CC BY-NC-SA 4.0</a> 2022-PRESENT © ryoppippi
+		<a href='https://creativecommons.org/licenses/by-nc-sa/4.0/' rel='noopener noreferrer' target='_blank'>CC BY-NC-SA 4.0</a> 2022-PRESENT © ryoppippi
 	</div>
 </div>
 

--- a/src/routes/blog/[slug]/prose.css
+++ b/src/routes/blog/[slug]/prose.css
@@ -28,6 +28,36 @@ html:not(.dark) .shiki {
 	background-color: theme('colors.text.150') !important;
 }
 
+@media (prefers-contrast: more) {
+	.prose .markdown-alert-title {
+		color: #0969da;
+	}
+
+	html.dark .prose .markdown-alert-title {
+		color: #58a6ff;
+	}
+
+	html.dark .shiki span[style*='--shiki-dark:#737C73'] {
+		--shiki-dark: #94a094 !important;
+	}
+
+	html:not(.dark) .shiki span[style*='color:#6F894E'] {
+		color: #3f6728 !important;
+	}
+
+	html:not(.dark) .shiki span[style*='color:#716E61'] {
+		color: #5f5a4e !important;
+	}
+
+	html:not(.dark) .shiki span[style*='color:#6693BF'] {
+		color: #2f668f !important;
+	}
+
+	html:not(.dark) .shiki span[style*='color:#B35B79'] {
+		color: #8a3156 !important;
+	}
+}
+
 .prose pre code {
 	--uno: font-code;
 }

--- a/src/routes/sponsors/+page.svelte
+++ b/src/routes/sponsors/+page.svelte
@@ -24,6 +24,8 @@
 </script>
 
 <div container fcol gap-8 mxa py-8>
+	<h1 class='sr-only'>Sponsors</h1>
+
 	<p op-card>
 		Thank you to everyone supporting my work—it keeps the OSS, blog, and talks
 		alive.
@@ -36,7 +38,7 @@
 			rel='noreferrer'
 			target='_blank'
 		>
-			<span class='i-ph-heart' />
+			<span class='i-ph-heart' aria-hidden='true' />
 			GitHub Sponsors
 		</a>
 	</p>

--- a/src/routes/works/+layout.svelte
+++ b/src/routes/works/+layout.svelte
@@ -16,7 +16,8 @@
 <div>
 	<ProjectTitle />
 
-	<div
+	<nav
+		aria-label='Works sections'
 		fcol-sm-row
 		fw
 		gap='1 sm:3'
@@ -30,11 +31,12 @@
 				style:--nav-title='project-nav-{route}'
 				style:view-transition-name='project-nav-{route}'
 				class={{ op70: isCurrent }}
+				aria-current={isCurrent ? 'page' : undefined}
 				href={isCurrent ? null : lowercaseRoute}
 				op20
 			>{capitalize(route)}</a>
 		{/each}
-	</div>
+	</nav>
 
 	{@render children()}
 </div>

--- a/src/routes/works/oss/+page.svelte
+++ b/src/routes/works/oss/+page.svelte
@@ -14,7 +14,7 @@
 <div grid='~ gap-16'>
 	{#each Object.entries(projects) as [genre, projectsByGenrne] (genre)}
 		<div>
-			<LargeTitle title={genre} />
+			<LargeTitle level={2} title={genre} />
 			<div
 				grid='~ gap-8'
 				grid-cols='1 md:2'

--- a/src/routes/works/publications/+page.svelte
+++ b/src/routes/works/publications/+page.svelte
@@ -42,7 +42,7 @@
 	{@const displayTitle = isOnlyEnglish && en ? en : (en ? `${ja} (${en})` : ja)}
 	<div mt-5>
 		<h3 text-xl>
-			<a class='underline' href={item.link} target='_blank'>{displayTitle}</a>
+			<span class='underline'>{displayTitle}</span>
 		</h3>
 		<p op50>{item.publisher}</p>
 	</div>
@@ -62,7 +62,7 @@
 		animate-delay-base
 		no-underline
 	>
-		<LargeTitle title={year} />
+		<LargeTitle level={2} title={year} />
 		<ListView
 			{itemView}
 			{items}

--- a/src/routes/works/talks/+page.svelte
+++ b/src/routes/works/talks/+page.svelte
@@ -20,13 +20,18 @@
 </script>
 
 {#snippet link(_link: string | null | undefined, _text: string)}
-	<a
-		class={_link == null ? 'no-underline' : 'underline'}
-		href={_link}
-		target='_blank'
-	>
-		{_text}
-	</a>
+	{#if _link == null}
+		<span>{_text}</span>
+	{:else}
+		<a
+			class='underline'
+			href={_link}
+			rel='noopener noreferrer'
+			target='_blank'
+		>
+			{_text}
+		</a>
+	{/if}
 {/snippet}
 
 {#snippet itemView(_item: ListItem)}
@@ -57,10 +62,11 @@
 		href='https://talks.ryoppippi.com/feed.xml'
 		mya
 		op30
+		rel='noopener noreferrer'
 		target='_blank'
 	>
 		<!-- svelte-ignore element_invalid_self_closing_tag -->
-		<span class='i-line-md:rss' />
+		<span class='i-line-md:rss' aria-hidden='true' />
 		Feed
 	</a>
 	<CheckButton
@@ -75,7 +81,7 @@
 		animate-delay-base
 		no-underline
 	>
-		<LargeTitle title={year} />
+		<LargeTitle level={2} title={year} />
 		<ListView
 			{itemView}
 			items={items as unknown as ListItem[]}


### PR DESCRIPTION
## Summary

Improves accessibility semantics across the site while preserving the normal visual design. The changes add skip navigation, clearer landmarks and labels, accessible state for filter buttons, safer external-link attributes, and valid heading hierarchy for repeated section titles.

## What Changed

- Added a skip link and moved the page body into a labelled main content target.
- Added accessible names or hidden decoration markers for icon-only and decorative icons.
- Exposed filter button state with aria-pressed.
- Removed nested anchors in works list content while keeping the same visible underlined title treatment.
- Added rel="noopener noreferrer" to external links that open in a new tab.
- Added prefers-contrast: more-only overrides for article alert/code colours so normal rendering remains unchanged.

## Testing

- pnpm lint
- pnpm check (passes with existing Svelte warnings)
- pnpm build
- axe-core smoke checks against /, /blog, /works/oss, /works/showcase, /works/talks, /works/publications, and /sponsors reported no violations. A sampled blog article still reports existing code-highlight colour contrast in normal contrast mode by design; the PR limits those colour adjustments to prefers-contrast: more.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves accessibility across the site without changing the visual design. Adds clearer landmarks, labels, states, safer external links, and guards Tweet embeds with a resilient fallback.

- **Bug Fixes**
  - Added a “Skip to content” link and a labeled, focusable main landmark.
  - Corrected heading hierarchy with `LargeTitle level` and sr-only titles; improved markdown header links; removed nested anchors.
  - Gave icon-only links accessible names; marked decorative icons `aria-hidden`.
  - Exposed filter button state with `aria-pressed` in `CheckButton`.
  - Secured `target="_blank"` links with `rel="noopener noreferrer"`.
  - Labeled nav landmarks (e.g., primary nav, works) and set `aria-current`.
  - Limited alert/code color tweaks to `prefers-contrast: more`.
  - Guarded Tweet embeds with a boundary and a fallback link to the X status to avoid prerender failures.

<sup>Written for commit 410528d62aa1f24950db536320ff222a8839ad2c. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2066?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

