### PR TITLE
fix: render tweet embeds during prerender

### DIFF
--- a/src/components/Tweet.svelte
+++ b/src/components/Tweet.svelte
@@ -8,9 +8,7 @@
 </script>
 
 <svelte:boundary>
-	{#await getTweet({ id }) then tweet}
-		<st.Tweet {tweet} />
-	{/await}
+	<st.Tweet tweet={await getTweet({ id })} />
 
 	{#snippet failed()}
 		<a href='https://x.com/i/web/status/{id}' rel='noopener noreferrer' target='_blank'>Tweet {id}</a>


### PR DESCRIPTION
Fixes tweet embeds disappearing from prerendered blog pages after adding the error boundary fallback.

The previous implementation used a Svelte await block inside the boundary. Svelte only renders the pending branch of await blocks during SSR, so the generated static HTML did not include the tweet cards. This keeps the boundary fallback but uses an async expression so successful tweet fetches are rendered during prerender.

Testing:
- CI=true pnpm build
- pnpm lint
- pnpm check
- Verified build/blog/2026-01-07-recap-2025-ja.html contains both tweet cards
- Verified local preview renders the tweet card with agent-browser screenshot


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix missing tweet embeds on prerendered blog pages by rendering tweets with an inline async expression inside the Svelte boundary. Keeps the error fallback for failed fetches and ensures SSR outputs the tweet cards.

- **Bug Fixes**
  - Replaced the await block with `tweet={await getTweet({ id })}` so SSR renders the resolved tweet instead of the pending branch. Verified prerendered pages and local preview show tweet cards.

<sup>Written for commit b253b27249bf0cd4b6846f8dd444473fd54f6130. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2067?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

