### PR TITLE
fix: stabilise Tailwind route CSS and nav layout

### DIFF
--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -7,15 +7,13 @@
 	import * as ufo from 'ufo';
 
 	const LINKS = [
-		{ name: 'works', href: resolve('/works') },
-		{ name: 'blog', href: resolve('/blog') },
-		{ name: 'sponsors', href: resolve('/sponsors') },
-		{
-			name: 'cv',
-			href: ufo.joinURL(PUBLIC_ORIGIN, '/cv'),
-			icon: 'icon-[line-md--download-outline]',
-		},
-	] as const satisfies { href: string; name: string; icon?: string }[];
+		{ name: 'works', href: '/works' },
+		{ name: 'blog', href: '/blog' },
+		{ name: 'sponsors', href: '/sponsors' },
+	] as const satisfies { href: string; name: string }[];
+
+	const CV_HREF = ufo.joinURL(PUBLIC_ORIGIN, '/cv');
+	const isHome = $derived(page.url.pathname === '/');
 </script>
 
 {#snippet underline(isPath: boolean, transparentDefault = false)}
@@ -28,7 +26,6 @@
 			{
 				'bg-accent-100': isPath,
 				'bg-transparent': !isPath || transparentDefault,
-				'view-transition--nav-underline': isPath,
 			},
 		]}
 	/>
@@ -36,12 +33,10 @@
 
 <header
 	class={[
-		'fcol',
-		'fyc',
-		'view-transition--nav',
 		'mx-auto',
 		'grid',
-		['grid-cols-1', 'md:grid-cols-3'],
+		['max-md:grid-cols-1', 'md:grid-cols-3'],
+		'items-center',
 		'gap-y-6',
 		'py-6',
 		'text-xl',
@@ -49,65 +44,67 @@
 		['transition-base', 'hover:opacity-100'],
 	]}
 >
-	<div class='flex'>
-		<a
-			class={[
-				'relative',
-				'mx-auto',
-				'font-bold',
-				['md:mx-0', 'md:mb-0'],
-			]}
-			aria-label='Home'
-			href={resolve('/')}
-		>
-			<div
-				style:view-transition-name='title-ryoppippi'
-				class={{ hidden: page.url.pathname === '/' }}
+	<div class={isHome ? ['max-md:hidden', 'md:flex'] : 'flex'}>
+		{#if !isHome}
+			<a
+				class={[
+					'relative',
+					'font-bold',
+					['max-md:mx-auto', 'md:mx-0', 'md:mb-0'],
+				]}
+				aria-label='Home'
+				href={resolve('/')}
 			>
-				@ryoppippi
-			</div>
-			<div>{@render underline(page.url.pathname === '/', true)}</div>
-		</a>
+				<div style:view-transition-name='title-ryoppippi'>@ryoppippi</div>
+				<div>{@render underline(isHome, true)}</div>
+			</a>
+		{/if}
 	</div>
 	<nav
 		class={[
-			'fxc',
-			'col-span-2',
-			'mx-auto',
+			'flex',
+			'w-full',
+			'max-w-full',
+			'md:col-span-2',
 			'flex-wrap',
-			'gap-4',
+			'gap-x-4',
+			'gap-y-4',
 			'text-lg',
 			'font-bold',
-			['md:mr-0', 'md:justify-end'],
+			['max-md:mx-auto', 'md:ml-auto', 'md:mr-0'],
+			['max-md:justify-center', 'md:justify-end'],
 		]}
 		aria-label='Primary navigation'
 	>
-		<div class='flex gap-4'>
-			{#each LINKS as { href, name, ...rest } (href)}
-				{@const isPath = page.url.pathname.startsWith(href)}
-				{@const icon = 'icon' in rest ? rest.icon : null}
-				<a
-					style:view-transition-name='-nav-link-{name}'
-					class='relative block px-0'
-					{href}
-					rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
-					target={href.startsWith('http') ? '_blank' : undefined}
-				>
-					<div class='fyc'>
-						{name}
-						{#if icon != null}
-							<Icon class={icon} aria-hidden='true' />
-						{/if}
-					</div>
-					{@render underline(isPath, false)}
-				</a>
-			{/each}
-		</div>
+		{#each LINKS as { href, name } (href)}
+			{@const isPath = page.url.pathname.startsWith(href)}
+			<a
+				class='relative block shrink-0 whitespace-nowrap px-0'
+				href={resolve(href)}
+			>
+				<div class='fyc'>
+					{name}
+				</div>
+				{@render underline(isPath, false)}
+			</a>
+		{/each}
+		<a
+			class='relative block w-10 shrink-0 whitespace-nowrap px-0'
+			href={CV_HREF}
+			rel='noopener noreferrer'
+			target='_blank'
+		>
+			<div class='fyc'>
+				cv
+				<Icon class='icon-[line-md--download-outline] size-[1em] shrink-0' aria-hidden='true' />
+			</div>
+			{@render underline(false, false)}
+		</a>
 		<div
 			class={[
-				'view-transition--nav-icons',
 				'flex',
-				['gap-4', 'md:gap-2'],
+				'w-[4.375rem]',
+				'justify-between',
 			]}
 		>
 			<DarkMode.ToggleButton>

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -77,10 +77,11 @@
 		aria-label='Primary navigation'
 	>
 		{#each LINKS as { href, name } (href)}
-			{@const isPath = page.url.pathname.startsWith(href)}
+			{@const resolvedHref = resolve(href)}
+			{@const isPath = page.url.pathname.startsWith(resolvedHref)}
 			<a
 				class='relative block shrink-0 whitespace-nowrap px-0'
-				href={resolve(href)}
+				href={resolvedHref}
 			>
 				<div class='fyc'>
 					{name}

--- a/src/components/Social.svelte
+++ b/src/components/Social.svelte
@@ -23,7 +23,7 @@
 	style:--cols={ICONS.length}
 	class={[
 		'gcc',
-		'animate-[fade-in_3s_both]',
+		'animate-[root-fade-in_3s_both]',
 		['grid-cols-3', 'sm:grid-cols-[repeat(var(--cols),minmax(0,1fr))]'],
 		'gap-3',
 	]}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 
 <article class='gcc container mx-auto mt-8'
 >
-	<div class='animate-[flip-in-x_1s_both]'>
+	<div class='animate-[root-flip-in-x_1s_both]'>
 		<Profile />
 	</div>
 	<div class='mt-8'>

--- a/src/routes/blog/[slug]/article.css
+++ b/src/routes/blog/[slug]/article.css
@@ -1,5 +1,7 @@
-@import 'tailwindcss' source(none);
-@import '../../../styles/tailwind.css';
+@layer theme, base, components, utilities;
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+@import '../../../styles/prose-theme.css';
+@reference '../../../styles/tailwind.css';
 
 @source './+page.svelte';
 @source '../../../contents/blog/**/*.md';

--- a/src/routes/blog/page.css
+++ b/src/routes/blog/page.css
@@ -1,5 +1,6 @@
-@import 'tailwindcss' source(none);
-@import '../../styles/tailwind.css';
+@layer theme, base, components, utilities;
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+@reference '../../styles/tailwind.css';
 
 @source './+page.svelte';
 @source '../../components/CheckButton.svelte';

--- a/src/routes/page.css
+++ b/src/routes/page.css
@@ -6,7 +6,7 @@
 @source '../components/Profile.svelte';
 @source '../components/Social.svelte';
 
-@keyframes fade-in {
+@keyframes root-fade-in {
 	from {
 		opacity: 0;
 	}
@@ -16,7 +16,7 @@
 	}
 }
 
-@keyframes flip-in-x {
+@keyframes root-flip-in-x {
 	0% {
 		opacity: 0;
 		animation-timing-function: ease-in;

--- a/src/routes/page.css
+++ b/src/routes/page.css
@@ -1,6 +1,43 @@
-@import 'tailwindcss' source(none);
-@import '../styles/tailwind.css';
+@layer theme, base, components, utilities;
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+@reference '../styles/tailwind.css';
 
 @source './+page.svelte';
 @source '../components/Profile.svelte';
 @source '../components/Social.svelte';
+
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes flip-in-x {
+	0% {
+		opacity: 0;
+		animation-timing-function: ease-in;
+		transform: perspective(400px) rotateX(90deg);
+	}
+
+	40% {
+		animation-timing-function: ease-in;
+		transform: perspective(400px) rotateX(-20deg);
+	}
+
+	60% {
+		opacity: 1;
+		transform: perspective(400px) rotateX(10deg);
+	}
+
+	80% {
+		transform: perspective(400px) rotateX(-5deg);
+	}
+
+	to {
+		transform: perspective(400px);
+	}
+}

--- a/src/routes/sponsors/page.css
+++ b/src/routes/sponsors/page.css
@@ -1,4 +1,5 @@
-@import 'tailwindcss' source(none);
-@import '../../styles/tailwind.css';
+@layer theme, base, components, utilities;
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+@reference '../../styles/tailwind.css';
 
 @source './+page.svelte';

--- a/src/routes/works/layout.css
+++ b/src/routes/works/layout.css
@@ -1,5 +1,7 @@
-@import 'tailwindcss' source(none);
-@import '../../styles/tailwind.css';
+@layer theme, base, components, utilities;
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+@import '../../styles/prose-theme.css';
+@reference '../../styles/tailwind.css';
 
 @source './';
 @source '../../components/CheckButton.svelte';

--- a/src/styles/prose-theme.css
+++ b/src/styles/prose-theme.css
@@ -1,0 +1,7 @@
+.prose {
+	--tw-prose-code: var(--color-text-800);
+	--tw-prose-invert-code: var(--color-text-100);
+	--tw-prose-hr: #7d7d7d4d;
+	--tw-prose-th-borders: #7d7d7d4d;
+	--tw-prose-td-borders: #7d7d7d4d;
+}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1,5 +1,4 @@
 @import url('https://fonts.bunny.net/css?family=bad-script:400|dm-mono:400,600|inter:400,600,800|jetbrains-mono:400,600|roboto-condensed:400,700&display=swap');
-@import 'tailwindcss' source(none);
 @import './tailwind.css';
 
 @source '../routes/+layout.svelte';

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -45,7 +45,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@media (width >= 48rem) {
+	@media (width >= theme(--breakpoint-md)) {
 		flex-direction: row;
 	}
 }
@@ -54,7 +54,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@media (width >= 40rem) {
+	@media (width >= theme(--breakpoint-sm)) {
 		flex-direction: row;
 	}
 }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,6 @@
+@layer theme, base, components, utilities;
+@import 'tailwindcss' source(none);
+
 @plugin '@tailwindcss/typography';
 @plugin '@iconify/tailwind4';
 
@@ -41,11 +44,19 @@
 @utility fcol-md-row {
 	display: flex;
 	flex-direction: column;
+
+	@media (width >= 48rem) {
+		flex-direction: row;
+	}
 }
 
 @utility fcol-sm-row {
 	display: flex;
 	flex-direction: column;
+
+	@media (width >= 40rem) {
+		flex-direction: row;
+	}
 }
 
 @utility fw {
@@ -109,18 +120,6 @@
 	view-transition-name: name---profile;
 }
 
-@utility view-transition--nav {
-	view-transition-name: -nav;
-}
-
-@utility view-transition--nav-icons {
-	view-transition-name: -nav-icons;
-}
-
-@utility view-transition--nav-underline {
-	view-transition-name: -nav-underline;
-}
-
 @utility btn-blue {
 	@apply border border-base rounded px-2.5 py-1 opacity-50 no-underline transition-all duration-200 ease-out hover:bg-[#60a5fa1a] hover:text-[#60a5fa] hover:opacity-100;
 }
@@ -131,60 +130,4 @@
 
 @utility btn-pink {
 	@apply border border-base rounded px-2.5 py-1 opacity-50 no-underline transition-all duration-200 ease-out hover:bg-[#f472b61a] hover:text-[#f472b6] hover:opacity-100;
-}
-
-@media (min-width: theme(--breakpoint-sm)) {
-	.fcol-sm-row {
-		flex-direction: row;
-	}
-}
-
-@media (min-width: theme(--breakpoint-md)) {
-	.fcol-md-row {
-		flex-direction: row;
-	}
-}
-
-@keyframes fade-in {
-	from {
-		opacity: 0;
-	}
-
-	to {
-		opacity: 1;
-	}
-}
-
-@keyframes flip-in-x {
-	0% {
-		opacity: 0;
-		animation-timing-function: ease-in;
-		transform: perspective(400px) rotateX(90deg);
-	}
-
-	40% {
-		animation-timing-function: ease-in;
-		transform: perspective(400px) rotateX(-20deg);
-	}
-
-	60% {
-		opacity: 1;
-		transform: perspective(400px) rotateX(10deg);
-	}
-
-	80% {
-		transform: perspective(400px) rotateX(-5deg);
-	}
-
-	to {
-		transform: perspective(400px);
-	}
-}
-
-.prose {
-	--tw-prose-code: var(--color-text-800);
-	--tw-prose-invert-code: var(--color-text-100);
-	--tw-prose-hr: #7d7d7d4d;
-	--tw-prose-th-borders: #7d7d7d4d;
-	--tw-prose-td-borders: #7d7d7d4d;
 }


### PR DESCRIPTION
## Summary

Stabilises the Tailwind v4 route CSS split and fixes the navigation layout regression that appeared after client-side navigation.

## What changed

- Keep Tailwind layer order explicit in route-level CSS entries while importing only route utilities.
- Move prose theme variables and root-only animations out of the global Tailwind entry.
- Restore desktop nav alignment after route transitions and keep mobile nav rows centred without label wrapping.

## Testing

- pnpm lint
- pnpm check
- pnpm build
- Browser check for mobile nav centring and desktop navigation return alignment

@coderabbitai review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `tailwindcss` route CSS ordering to prevent utility overrides after navigation. Restores header/nav alignment on desktop and keeps mobile nav centered.

- **Bug Fixes**
  - Restore desktop header alignment by rendering the home link only off-root and using exclusive responsive variants; keep mobile nav rows centered and labels unwrapped.
  - Fix active-link highlighting with base paths by resolving local hrefs before matching.
  - Avoid keyframe name collisions by renaming home-page animations to route-scoped names.

- **Refactors**
  - Declare explicit layer order and import route-only `tailwindcss/utilities.css`; use `@reference` for the global entry so route chunks can’t override shared styles.
  - Move prose theme variables to `src/styles/prose-theme.css`; keep root-only animations in route CSS; keep shared utilities in `src/styles/tailwind.css`.
  - Use Tailwind breakpoint tokens in custom utilities instead of hardcoded media queries; remove stale view-transition utilities.

<sup>Written for commit 88833650962a17d21d94ecf2ec31f589fa142f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fade-in and flip-in-x animation effects.

* **Style**
  * Refactored navigation layout and styling; CV link now displays separately.
  * Updated typography and prose styling with custom theme colors.
  * Switched to external font imports for improved typography rendering.
  * Optimized CSS layer structure across pages for better style organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->