### PR TITLE
fix(sponsors): use dedicated sponsor asset host

### DIFF
--- a/src/contents/blog/2025-06-18-zenn-aad087994f26a7-ja/index.md
+++ b/src/contents/blog/2025-06-18-zenn-aad087994f26a7-ja/index.md
@@ -29,7 +29,7 @@ lang: 'ja'
 >
 > スポンサーしていただいている方々にはとても感謝しています。ありがとうございます！
 >
-> [![spnosors](https://cdn.jsdelivr.net/gh/ryoppippi/sponsors/sponsors.circles.svg)](https://github.com/ryoppippi/sponsors)
+> [![spnosors](https://sponsors.ryoppippi.com/sponsors.circles.svg)](https://github.com/ryoppippi/sponsors)
 
 # はじめに
 

--- a/src/contents/blog/2025-09-20-ccusage-for-codex/index.md
+++ b/src/contents/blog/2025-09-20-ccusage-for-codex/index.md
@@ -180,5 +180,5 @@ bunx @ccusage/mcp@latest --help
 
 （いただいたスポンサーのうち、一部は ccusage の contributor に再分配しています）
 
-![sponsor](https://cdn.jsdelivr.net/gh/ryoppippi/sponsor@main/sponsors.circles.svg)
+![sponsor](https://sponsors.ryoppippi.com/sponsors.circles.svg)
 [@preview](https://ccusage.com/sponsor)

--- a/src/contents/blog/2026-01-07-recap-2025-ja/index.md
+++ b/src/contents/blog/2026-01-07-recap-2025-ja/index.md
@@ -60,7 +60,7 @@ import Tweet from '$components/Tweet.svelte';
 特に[toyokumo様にThanks OSS Award](https://oss.toyokumo.co.jp/results/2025-last-half)に選んでいただいたのは、一つの目標でもあったのでとても嬉しかった。
 感謝してもしきれない。
 
-![sponsor](https://cdn.jsdelivr.net/gh/ryoppippi/sponsors@main/sponsors.circles.svg)
+![sponsor](https://sponsors.ryoppippi.com/sponsors.circles.svg)
 
 ## 2026年に向けて
 

--- a/src/routes/sponsors/+page.svelte
+++ b/src/routes/sponsors/+page.svelte
@@ -6,13 +6,13 @@
 		{
 			id: 'circles',
 			label: 'Sponsor Circles',
-			src: 'https://cdn.jsdelivr.net/gh/ryoppippi/sponsors@main/sponsors.circles.svg',
+			src: 'https://sponsors.ryoppippi.com/sponsors.circles.svg',
 			alt: 'GitHub Sponsors',
 		},
 		{
 			id: 'tiers',
 			label: 'Sponsor Tiers',
-			src: 'https://cdn.jsdelivr.net/gh/ryoppippi/sponsors@main/sponsors.past.svg',
+			src: 'https://sponsors.ryoppippi.com/sponsors.past.svg',
 			alt: 'Sponsor Tiers',
 		},
 	] as const;


### PR DESCRIPTION
Replace sponsor image references that used jsDelivr GitHub URLs with \`https://sponsors.ryoppippi.com\`.

This keeps the sponsors page and older posts pointed at the new dedicated sponsor asset host while preserving the existing circle and tier image filenames.

Testing:
- \`env PUBLIC_ORIGIN=https://ryoppippi.com pnpm check\`
- \`pnpm lint\`
- \`env PUBLIC_ORIGIN=https://ryoppippi.com pnpm build\`

@coderabbitai review


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched sponsor image URLs from jsDelivr GitHub CDN to https://sponsors.ryoppippi.com to reduce external dependencies and keep assets under our domain. Applies to the sponsors page and three blog posts; filenames for circle and past tier images are unchanged.

<sup>Written for commit 7dd8027911d3e2590ce452abacc8c3731781fefc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

