### PR TITLE
fix(markdown): restore blog rendering regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/node": "^24.12.3",
 		"arktype": "^2.2.0",
+		"budoux": "^0.8.4",
 		"date-fns": "^4.1.0",
 		"diacritics": "^1.3.0",
 		"eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       arktype:
         specifier: ^2.2.0
         version: 2.2.0
+      budoux:
+        specifier: ^0.8.4
+        version: 0.8.4
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1382,8 +1385,16 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1425,10 +1436,16 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.7:
     resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -1448,6 +1465,13 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  budoux@0.8.4:
+    resolution: {integrity: sha512-EogZewMIXDePuJeBetf2hQphKsTWup3oTaf4q4ibc3NPPW+wAvfpk5AsC71BxcfowGeO/5cHvzGd/d0x8bIYXQ==}
+    hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   builtin-modules@5.2.0:
     resolution: {integrity: sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==}
@@ -1503,6 +1527,10 @@ packages:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   cloudflare-redirect-parser@1.0.0:
     resolution: {integrity: sha512-puEB3wmP47RICu/CboTHd237Up/r3Nagsr622mJxWgvEVfRxNlKceNfpPieMYDe/E1nYJsf6iempsrkitgQZVw==}
 
@@ -1523,6 +1551,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   comment-parser@1.4.1:
     resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
@@ -1582,6 +1614,9 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -1665,8 +1700,14 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1982,6 +2023,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2087,6 +2131,18 @@ packages:
   fzf@0.5.2:
     resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
@@ -2123,6 +2179,18 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  google-artifactregistry-auth@3.5.0:
+    resolution: {integrity: sha512-SIvVBPjVr0KvYFEJEZXKfELt8nvXwTKl6IHyOT7pTHBlS8Ej2UuTOJeKWYFim/JztSjUyna9pKQxa3VhTA12Fg==}
+    hasBin: true
+
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2132,6 +2200,10 @@ packages:
   gray-matter-es@0.2.1:
     resolution: {integrity: sha512-LCBpytO2B2da+CRuO95voiszbEICp2o8CkoKvcCkv4MCgP/TJm78yMPt0IDRq72k3xGHLNofmCAT/+vv3qX3eg==}
     engines: {node: '>=20.19.6'}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2143,8 +2215,18 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
@@ -2186,6 +2268,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -2209,6 +2295,10 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
@@ -2255,6 +2345,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2277,6 +2370,12 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2427,6 +2526,15 @@ packages:
   line-column-path@4.0.0:
     resolution: {integrity: sha512-Zvpvd56i9FRV5kaJFiiY1t+FNMEH+dGEaLyQprqKlGHBAxJXmdSk+8tVsh6b9YlxbfyyuLrhJCkzwB+AmOBZ0g==}
     engines: {node: '>=20'}
+
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
@@ -2636,6 +2744,15 @@ packages:
   natural-orderby@5.0.0:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -2940,6 +3057,10 @@ packages:
     resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
     hasBin: true
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2969,6 +3090,9 @@ packages:
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   sax@1.5.0:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
@@ -3058,8 +3182,16 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
@@ -3202,6 +3334,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -3253,6 +3388,9 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -3301,6 +3439,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -3419,8 +3562,14 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -3439,6 +3588,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -3468,6 +3621,10 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml-eslint-parser@1.3.2:
     resolution: {integrity: sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==}
     engines: {node: ^14.17.0 || >=16.0.0}
@@ -3484,6 +3641,14 @@ packages:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4626,12 +4791,16 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -4663,7 +4832,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.7: {}
+
+  bignumber.js@9.3.1: {}
 
   boolbase@1.0.0: {}
 
@@ -4687,6 +4860,18 @@ snapshots:
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  budoux@0.8.4:
+    dependencies:
+      commander: 14.0.3
+      google-artifactregistry-auth: 3.5.0
+      linkedom: 0.18.12
+    transitivePeerDependencies:
+      - canvas
+      - encoding
+      - supports-color
+
+  buffer-equal-constant-time@1.0.1: {}
 
   builtin-modules@5.2.0: {}
 
@@ -4727,6 +4912,12 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cloudflare-redirect-parser@1.0.0: {}
 
   clsx@2.1.1: {}
@@ -4740,6 +4931,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
+
+  commander@14.0.3: {}
 
   comment-parser@1.4.1: {}
 
@@ -4792,6 +4985,8 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  cssom@0.5.0: {}
 
   date-fns@4.1.0: {}
 
@@ -4856,7 +5051,13 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   electron-to-chromium@1.5.313: {}
+
+  emoji-regex@8.0.0: {}
 
   empathic@2.0.0: {}
 
@@ -5258,6 +5459,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -5363,6 +5566,28 @@ snapshots:
 
   fzf@0.5.2: {}
 
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  get-caller-file@2.0.5: {}
+
   get-stream@9.0.1:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
@@ -5392,11 +5617,42 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  google-artifactregistry-auth@3.5.0:
+    dependencies:
+      google-auth-library: 9.15.1
+      js-yaml: 4.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
   gray-matter-es@0.2.1: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   has-flag@4.0.0: {}
 
@@ -5418,7 +5674,23 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-escaper@3.0.3: {}
+
   html-void-elements@3.0.0: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@8.0.1: {}
 
@@ -5445,6 +5717,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -5462,6 +5736,8 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  is-stream@2.0.1: {}
 
   is-stream@4.0.1: {}
 
@@ -5489,6 +5765,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-rpc-2.0@1.7.1: {}
@@ -5515,6 +5795,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -5626,6 +5917,14 @@ snapshots:
   line-column-path@4.0.0:
     dependencies:
       unicorn-magic: 0.4.0
+
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
 
   local-pkg@1.1.2:
     dependencies:
@@ -6026,6 +6325,10 @@ snapshots:
 
   natural-orderby@5.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.36: {}
 
   node@runtime:24.15.0: {}
@@ -6242,6 +6545,8 @@ snapshots:
     dependencies:
       jsesc: 3.0.2
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -6283,6 +6588,8 @@ snapshots:
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
+
+  safe-buffer@5.2.1: {}
 
   sax@1.5.0: {}
 
@@ -6393,10 +6700,20 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-final-newline@4.0.0: {}
 
@@ -6555,6 +6872,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tr46@0.0.3: {}
+
   trim-lines@3.0.1: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -6602,6 +6921,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
+
+  uhyphen@0.2.0: {}
 
   undici-types@7.16.0: {}
 
@@ -6654,6 +6975,8 @@ snapshots:
   uri-template-matcher@1.1.2: {}
 
   util-deprecate@1.0.2: {}
+
+  uuid@9.0.1: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
@@ -6733,7 +7056,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-pm-runs@1.1.0: {}
 
@@ -6747,6 +7077,12 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wsl-utils@0.3.1:
     dependencies:
@@ -6778,6 +7114,8 @@ snapshots:
 
   xmlbuilder@11.0.1: {}
 
+  y18n@5.0.8: {}
+
   yaml-eslint-parser@1.3.2:
     dependencies:
       eslint-visitor-keys: 3.4.3
@@ -6791,6 +7129,18 @@ snapshots:
   yaml@1.10.2: {}
 
   yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/src/markdown/budoux.ts
+++ b/src/markdown/budoux.ts
@@ -1,0 +1,103 @@
+import { loadDefaultJapaneseParser } from 'budoux';
+
+const paragraphWordBreakStyle = 'word-break:keep-all;overflow-wrap:anywhere;';
+const zeroWidthSpace = '\u200B';
+const skippedTextTags = new Set(['code', 'pre', 'script', 'style']);
+const japaneseParser = loadDefaultJapaneseParser();
+
+function applyParagraphStyle(tag: string) {
+	return tag.replace(/^<p(\s[^>]*)?>$/i, (match, attrs: string | undefined) => {
+		if (attrs == null) {
+			return `<p style="${paragraphWordBreakStyle}">`;
+		}
+
+		const styleMatch = attrs.match(/\sstyle=(["'])(.*?)\1/i);
+		if (styleMatch == null) {
+			return `<p${attrs} style="${paragraphWordBreakStyle}">`;
+		}
+
+		const separator = styleMatch[2].endsWith(';') ? '' : ';';
+		const style = `${styleMatch[2]}${separator}${paragraphWordBreakStyle}`;
+		return `<p${attrs.replace(styleMatch[0], ` style=${styleMatch[1]}${style}${styleMatch[1]}`)}>`;
+	});
+}
+
+function segmentText(text: string) {
+	if (text.trim().length === 0) {
+		return text;
+	}
+
+	return text
+		.split(/(&(?:#\d+|#x[\da-f]+|[a-z][a-z\d]+);)/i)
+		.map((chunk, index) => index % 2 === 1 ? chunk : japaneseParser.parse(chunk).join(zeroWidthSpace))
+		.join('');
+}
+
+export function applyBudouxHtml(html: string) {
+	const chunks: string[] = [];
+	const tagPattern = /<!--[\s\S]*?-->|<\/?([a-z][\w:-]*)\b[^>]*>/gi;
+	const skipStack: string[] = [];
+	let lastIndex = 0;
+
+	for (const match of html.matchAll(tagPattern)) {
+		const [tag, tagName] = match;
+		const index = match.index;
+		const text = html.slice(lastIndex, index);
+		chunks.push(skipStack.length > 0 ? text : segmentText(text));
+
+		const normalizedTagName = tagName?.toLowerCase();
+		if (normalizedTagName === 'p' && /^<p(?:\s|>)/i.test(tag)) {
+			chunks.push(applyParagraphStyle(tag));
+		}
+		else {
+			chunks.push(tag);
+		}
+
+		if (normalizedTagName != null && skippedTextTags.has(normalizedTagName)) {
+			if (tag.startsWith('</')) {
+				const stackIndex = skipStack.lastIndexOf(normalizedTagName);
+				if (stackIndex >= 0) {
+					skipStack.splice(stackIndex, 1);
+				}
+			}
+			else if (!tag.endsWith('/>')) {
+				skipStack.push(normalizedTagName);
+			}
+		}
+
+		lastIndex = index + tag.length;
+	}
+
+	const tail = html.slice(lastIndex);
+	chunks.push(skipStack.length > 0 ? tail : segmentText(tail));
+	return chunks.join('');
+}
+
+if (import.meta.vitest != null) {
+	describe('applyBudouxHtml', () => {
+		it('adds paragraph line-break style and zero-width spaces to Japanese text', () => {
+			expect(applyBudouxHtml('<p>今日は天気です。</p>')).toBe(
+				`<p style="${paragraphWordBreakStyle}">今日は${zeroWidthSpace}天気です。</p>`,
+			);
+		});
+
+		it('preserves existing paragraph style attributes', () => {
+			expect(applyBudouxHtml('<p style="color:red">今日は天気です。</p>')).toBe(
+				`<p style="color:red;${paragraphWordBreakStyle}">今日は${zeroWidthSpace}天気です。</p>`,
+			);
+		});
+
+		it('does not segment code block contents', () => {
+			expect(applyBudouxHtml('<p>今日は天気です。</p><pre><code>今日は天気です。</code></pre>')).toContain(
+				'<pre><code>今日は天気です。</code></pre>',
+			);
+		});
+
+		it('preserves html entities while segmenting text', () => {
+			const html = applyBudouxHtml('<p>今日は&amp;天気です。</p>');
+
+			expect(html).toContain('&amp;');
+			expect(html).not.toContain(`&${zeroWidthSpace}amp;`);
+		});
+	});
+}

--- a/src/markdown/collapsible.ts
+++ b/src/markdown/collapsible.ts
@@ -1,0 +1,126 @@
+import { escapeHtml } from './html.ts';
+
+type CollapsibleMarker = {
+	marker: string;
+	title: string;
+	open: boolean;
+};
+
+function parseCollapsibleMarker(line: string): CollapsibleMarker | null {
+	let indent = 0;
+	while (indent < line.length && line[indent] === ' ') {
+		indent += 1;
+	}
+
+	if (indent > 3) {
+		return null;
+	}
+
+	const rest = line.slice(indent);
+	let markerLength = 0;
+	while (markerLength < rest.length && rest[markerLength] === '+') {
+		markerLength += 1;
+	}
+
+	if (markerLength < 2) {
+		return null;
+	}
+
+	const open = rest[markerLength] === '>';
+	if (markerLength < 3 && !open) {
+		return null;
+	}
+
+	const marker = `${'+'.repeat(markerLength)}${open ? '>' : ''}`;
+	return {
+		marker,
+		title: rest.slice(marker.length).trim(),
+		open,
+	};
+}
+
+function renderCollapsibleSummary(title: string) {
+	return `<summary><span class="details-marker"></span>${escapeHtml(title)}</summary>`;
+}
+
+export function transformCollapsibleBlocks(content: string) {
+	const lines = content.split('\n');
+	const markerStack: string[] = [];
+	let inFence = false;
+	let fenceMarker = '';
+	let inScript = false;
+
+	return lines.map((line) => {
+		const trimmed = line.trimStart();
+		const fence = trimmed.match(/^(`{3,}|~{3,})/)?.[1];
+
+		if (inScript) {
+			if (trimmed === '</script>') {
+				inScript = false;
+			}
+			return line;
+		}
+
+		if (/^<script(?:\s|>)/.test(trimmed)) {
+			inScript = true;
+			return line;
+		}
+
+		if (fence != null) {
+			if (!inFence) {
+				inFence = true;
+				fenceMarker = fence;
+			}
+			else if (trimmed.startsWith(fenceMarker[0]) && fence.length >= fenceMarker.length) {
+				inFence = false;
+				fenceMarker = '';
+			}
+
+			return line;
+		}
+
+		if (inFence) {
+			return line;
+		}
+
+		const collapsible = parseCollapsibleMarker(line);
+		if (collapsible == null) {
+			return line;
+		}
+
+		if (collapsible.title.length === 0) {
+			const lastMarker = markerStack.at(-1);
+			if (lastMarker !== collapsible.marker) {
+				return line;
+			}
+
+			markerStack.pop();
+			return '</details>';
+		}
+
+		markerStack.push(collapsible.marker);
+		return `<details${collapsible.open ? ' open' : ''}>${renderCollapsibleSummary(collapsible.title)}`;
+	}).join('\n');
+}
+
+if (import.meta.vitest != null) {
+	describe('transformCollapsibleBlocks', () => {
+		it('converts collapsible blocks to details html', () => {
+			expect(transformCollapsibleBlocks('+++ More\nbody\n+++')).toBe(
+				'<details><summary><span class="details-marker"></span>More</summary>\nbody\n</details>',
+			);
+		});
+
+		it('converts open collapsible blocks to open details html', () => {
+			expect(transformCollapsibleBlocks('++> More\nbody\n++>')).toBe(
+				'<details open><summary><span class="details-marker"></span>More</summary>\nbody\n</details>',
+			);
+		});
+
+		it('leaves collapsible markers inside fenced code untouched', () => {
+			expect(transformCollapsibleBlocks('```md\n+++ More\n```\n+++ Real\nbody\n+++')).toBe(
+				'```md\n+++ More\n```\n<details><summary><span class="details-marker"></span>Real</summary>\nbody\n</details>',
+			);
+		});
+	});
+}

--- a/src/markdown/image-figures.ts
+++ b/src/markdown/image-figures.ts
@@ -1,0 +1,22 @@
+import { escapeHtml } from './html.ts';
+
+function renderImageFigure(alt: string, src: string, title: string) {
+	return `<figure><img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}" title="${escapeHtml(title)}" loading="lazy" decoding="async"><figcaption>${escapeHtml(title)}</figcaption></figure>`;
+}
+
+export function replaceImageFigures(line: string) {
+	return line.replace(
+		/!\[([^\]]*)\]\((\S+)\s+(['"])(.*?)\3\)(?:\{[^}\n]+\})?/g,
+		(_match, alt: string, src: string, _quote: string, title: string) => renderImageFigure(alt, src, title),
+	);
+}
+
+if (import.meta.vitest != null) {
+	describe('replaceImageFigures', () => {
+		it('converts markdown images with title attributes to image figures', () => {
+			expect(replaceImageFigures('![alt](./image.png "caption"){width=480}')).toBe(
+				'<figure><img src="./image.png" alt="alt" title="caption" loading="lazy" decoding="async"><figcaption>caption</figcaption></figure>',
+			);
+		});
+	});
+}

--- a/src/markdown/link-preview.ts
+++ b/src/markdown/link-preview.ts
@@ -1,0 +1,34 @@
+import { escapeHtml } from './html.ts';
+
+function renderLinkPreview(url: string) {
+	if (!/^https?:\/\//.test(url)) {
+		return null;
+	}
+
+	try {
+		const parsed = new URL(url);
+		const escapedUrl = escapeHtml(url);
+		return `<div class="link-preview-widget"><a href="${escapedUrl}" rel="noopener" target="_blank"><div class="link-preview-widget-title">${escapeHtml(url)}</div><div class="link-preview-widget-url">${escapeHtml(parsed.hostname)}</div></a></div>`;
+	}
+	catch {
+		return null;
+	}
+}
+
+export function replaceLinkPreviews(line: string) {
+	return line.replace(/\[@preview\]\((https?:\/\/[^)\s]+)\)/g, (match, url: string) => renderLinkPreview(url) ?? match);
+}
+
+if (import.meta.vitest != null) {
+	describe('replaceLinkPreviews', () => {
+		it('converts preview links to link card html', () => {
+			expect(replaceLinkPreviews('[@preview](https://github.com/junkawa/figma_jp)')).toBe(
+				'<div class="link-preview-widget"><a href="https://github.com/junkawa/figma_jp" rel="noopener" target="_blank"><div class="link-preview-widget-title">https://github.com/junkawa/figma_jp</div><div class="link-preview-widget-url">github.com</div></a></div>',
+			);
+		});
+
+		it('leaves malformed preview links untouched', () => {
+			expect(replaceLinkPreviews('[@preview](https://%)')).toBe('[@preview](https://%)');
+		});
+	});
+}

--- a/src/markdown/linkify.ts
+++ b/src/markdown/linkify.ts
@@ -1,0 +1,77 @@
+function normalizeAngleUrl(url: string) {
+	return url.replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
+export function normalizeAngleLinks(line: string) {
+	return line
+		.replace(/\[([^\]]+)\]\(<(https?:\/\/[^>\s]+)>\)/g, (_match, label: string, url: string) => `[${label}](${normalizeAngleUrl(url)})`)
+		.replace(/<(https?:\/\/[^>\s]+)>/g, (_match, url: string) => `[${url}](${normalizeAngleUrl(url)})`);
+}
+
+const trailingBareUrlPunctuationPattern = /[),.:;!?]+$/;
+
+function shouldTrimTrailingBareUrlPunctuation(url: string) {
+	const last = url.at(-1);
+	if (last == null) {
+		return false;
+	}
+
+	if (last !== ')') {
+		return trailingBareUrlPunctuationPattern.test(last);
+	}
+
+	const openingParens = (url.match(/\(/g) ?? []).length;
+	const closingParens = (url.match(/\)/g) ?? []).length;
+	return closingParens > openingParens;
+}
+
+function normaliseBareUrlLink(url: string) {
+	let linkUrl = url;
+	let trailingPunctuation = '';
+
+	while (shouldTrimTrailingBareUrlPunctuation(linkUrl)) {
+		trailingPunctuation = `${linkUrl.at(-1)}${trailingPunctuation}`;
+		linkUrl = linkUrl.slice(0, -1);
+	}
+
+	const normalisedLinkUrl = normalizeAngleUrl(linkUrl);
+	return `[${linkUrl}](${normalisedLinkUrl})${trailingPunctuation}`;
+}
+
+export function replaceBareUrls(line: string) {
+	if (line.includes('`') || line.includes('<') || line.includes('](')) {
+		return line;
+	}
+
+	return line.replace(/(^|[\s([>])(https?:\/\/[^\s<]+)/g, (_match, prefix: string, url: string) => {
+		return `${prefix}${normaliseBareUrlLink(url)}`;
+	});
+}
+
+if (import.meta.vitest != null) {
+	describe('normalizeAngleLinks', () => {
+		it('normalises angle links that contain parentheses', () => {
+			expect(normalizeAngleLinks('[release](<https://example.com/a(1)>)')).toBe(
+				'[release](https://example.com/a%281%29)',
+			);
+		});
+
+		it('normalises bare angle links that contain parentheses', () => {
+			expect(normalizeAngleLinks('<https://example.com/a(1)>')).toBe(
+				'[https://example.com/a(1)](https://example.com/a%281%29)',
+			);
+		});
+	});
+
+	describe('replaceBareUrls', () => {
+		it('converts bare URLs to markdown links', () => {
+			expect(replaceBareUrls('> https://example.com/a(1).')).toBe(
+				'> [https://example.com/a(1)](https://example.com/a%281%29).',
+			);
+		});
+
+		it('leaves existing markdown links untouched', () => {
+			expect(replaceBareUrls('[site](https://example.com)')).toBe('[site](https://example.com)');
+		});
+	});
+}

--- a/src/markdown/preprocessor.ts
+++ b/src/markdown/preprocessor.ts
@@ -87,8 +87,7 @@ function additionalProcessMd(proceed: string): string {
 			proceed.split('\n'),
 			map((line) => {
 				if (line.includes(`link-preview-widget`)) {
-					/* remove <p>, </p> */
-					line = line.replace(/<p>/g, '').replace(/<\/p>/g, '');
+					line = line.replace(/<p\b[^>]*>/g, '').replace(/<\/p>/g, '');
 					return line;
 				}
 				return line;
@@ -102,7 +101,7 @@ function additionalProcessMd(proceed: string): string {
 	result = addExternalLinkAttributes(result);
 	result = result.replace(/(<\/a>|<img\b[^>]*>)\{[^}\n]+\}/g, '$1');
 	result = result.replace(
-		/<p>(\s*<[A-Z][\w.]*\b[^>]*(?:\/>|>[\s\S]*?<\/[A-Z][\w.]*>)\s*)<\/p>/g,
+		/<p\b[^>]*>(\s*<[A-Z][\w.]*\b[^>]*(?:\/>|>[\s\S]*?<\/[A-Z][\w.]*>)\s*)<\/p>/g,
 		'$1',
 	);
 
@@ -409,8 +408,18 @@ if (import.meta.vitest != null) {
 			expect(additionalProcessMd('<p><Tweet id="123" /></p>')).toBe('<Tweet id="123" />');
 		});
 
+		it('unwraps Svelte component paragraphs with attributes', () => {
+			expect(additionalProcessMd('<p style="word-break:keep-all"><Tweet id="123" /></p>')).toBe('<Tweet id="123" />');
+		});
+
 		it('unwraps link preview widgets from paragraphs', () => {
 			expect(additionalProcessMd('<p><div class="link-preview-widget"></div></p>')).toBe(
+				'<div class="link-preview-widget"></div>',
+			);
+		});
+
+		it('unwraps link preview widgets from paragraphs with attributes', () => {
+			expect(additionalProcessMd('<p style="word-break:keep-all"><div class="link-preview-widget"></div></p>')).toBe(
 				'<div class="link-preview-widget"></div>',
 			);
 		});

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -31,6 +31,12 @@ type FenceLine = {
 	info: string;
 };
 
+type CollapsibleMarker = {
+	marker: string;
+	title: string;
+	open: boolean;
+};
+
 async function highlightCode(code: string, lang: string) {
 	return codeToHtml(code, {
 		lang,
@@ -71,6 +77,103 @@ function transformOutsideFences(content: string, transform: (line: string) => st
 		}
 
 		return inFence ? line : transform(line);
+	}).join('\n');
+}
+
+function parseCollapsibleMarker(line: string): CollapsibleMarker | null {
+	let indent = 0;
+	while (indent < line.length && line[indent] === ' ') {
+		indent += 1;
+	}
+
+	if (indent > 3) {
+		return null;
+	}
+
+	const rest = line.slice(indent);
+	let markerLength = 0;
+	while (markerLength < rest.length && rest[markerLength] === '+') {
+		markerLength += 1;
+	}
+
+	if (markerLength < 2) {
+		return null;
+	}
+
+	const open = rest[markerLength] === '>';
+	if (markerLength < 3 && !open) {
+		return null;
+	}
+
+	const marker = `${'+'.repeat(markerLength)}${open ? '>' : ''}`;
+	return {
+		marker,
+		title: rest.slice(marker.length).trim(),
+		open,
+	};
+}
+
+function renderCollapsibleSummary(title: string) {
+	return `<summary><span class="details-marker"></span>${escapeHtml(title)}</summary>`;
+}
+
+function transformCollapsibleBlocks(content: string) {
+	const lines = content.split('\n');
+	const markerStack: string[] = [];
+	let inFence = false;
+	let fenceMarker = '';
+	let inScript = false;
+
+	return lines.map((line) => {
+		const trimmed = line.trimStart();
+		const fence = trimmed.match(/^(`{3,}|~{3,})/)?.[1];
+
+		if (inScript) {
+			if (trimmed === '</script>') {
+				inScript = false;
+			}
+			return line;
+		}
+
+		if (/^<script(?:\s|>)/.test(trimmed)) {
+			inScript = true;
+			return line;
+		}
+
+		if (fence != null) {
+			if (!inFence) {
+				inFence = true;
+				fenceMarker = fence;
+			}
+			else if (trimmed.startsWith(fenceMarker[0]) && fence.length >= fenceMarker.length) {
+				inFence = false;
+				fenceMarker = '';
+			}
+
+			return line;
+		}
+
+		if (inFence) {
+			return line;
+		}
+
+		const collapsible = parseCollapsibleMarker(line);
+		if (collapsible == null) {
+			return line;
+		}
+
+		if (collapsible.title.length === 0) {
+			const lastMarker = markerStack.at(-1);
+			if (lastMarker !== collapsible.marker) {
+				return line;
+			}
+
+			markerStack.pop();
+			return '</details>';
+		}
+
+		markerStack.push(collapsible.marker);
+		return `<details${collapsible.open ? ' open' : ''}>${renderCollapsibleSummary(collapsible.title)}`;
 	}).join('\n');
 }
 
@@ -117,13 +220,57 @@ function renderImageFigure(alt: string, src: string, title: string) {
 	return `<figure><img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}" title="${escapeHtml(title)}" loading="lazy" decoding="async"><figcaption>${escapeHtml(title)}</figcaption></figure>`;
 }
 
+const trailingBareUrlPunctuationPattern = /[),.:;!?]+$/;
+
+function shouldTrimTrailingBareUrlPunctuation(url: string) {
+	const last = url.at(-1);
+	if (last == null) {
+		return false;
+	}
+
+	if (last !== ')') {
+		return trailingBareUrlPunctuationPattern.test(last);
+	}
+
+	const openingParens = (url.match(/\(/g) ?? []).length;
+	const closingParens = (url.match(/\)/g) ?? []).length;
+	return closingParens > openingParens;
+}
+
+function normaliseBareUrlLink(url: string) {
+	let linkUrl = url;
+	let trailingPunctuation = '';
+
+	while (shouldTrimTrailingBareUrlPunctuation(linkUrl)) {
+		trailingPunctuation = `${linkUrl.at(-1)}${trailingPunctuation}`;
+		linkUrl = linkUrl.slice(0, -1);
+	}
+
+	const normalisedLinkUrl = normalizeAngleUrl(linkUrl);
+	return `[${linkUrl}](${normalisedLinkUrl})${trailingPunctuation}`;
+}
+
+function replaceBareUrls(line: string) {
+	if (line.includes('`') || line.includes('<') || line.includes('](')) {
+		return line;
+	}
+
+	return line.replace(/(^|[\s([>])(https?:\/\/[^\s<]+)/g, (_match, prefix: string, url: string) => {
+		return `${prefix}${normaliseBareUrlLink(url)}`;
+	});
+}
+
 function prepareOxContentMarkdown(content: string) {
 	return transformOutsideFences(
-		content,
-		line => replaceLinkPreviews(normalizeAngleLinks(escapeMagicLinkUnderscores(line))).replace(
-			/!\[([^\]]*)\]\((\S+)\s+(['"])(.*?)\3\)(?:\{[^}\n]+\})?/g,
-			(_match, alt: string, src: string, _quote: string, title: string) => renderImageFigure(alt, src, title),
-		),
+		transformCollapsibleBlocks(content),
+		(line) => {
+			const preparedLine = replaceLinkPreviews(normalizeAngleLinks(escapeMagicLinkUnderscores(line))).replace(
+				/!\[([^\]]*)\]\((\S+)\s+(['"])(.*?)\3\)(?:\{[^}\n]+\})?/g,
+				(_match, alt: string, src: string, _quote: string, title: string) => renderImageFigure(alt, src, title),
+			);
+
+			return replaceBareUrls(preparedLine);
+		},
 	);
 }
 
@@ -337,6 +484,34 @@ if (import.meta.vitest != null) {
 			);
 		});
 
+		it('converts collapsible blocks to details html', () => {
+			expect(prepareOxContentMarkdown('+++ More\nbody\n+++')).toBe(
+				'<details><summary><span class="details-marker"></span>More</summary>\nbody\n</details>',
+			);
+		});
+
+		it('converts open collapsible blocks to open details html', () => {
+			expect(prepareOxContentMarkdown('++> More\nbody\n++>')).toBe(
+				'<details open><summary><span class="details-marker"></span>More</summary>\nbody\n</details>',
+			);
+		});
+
+		it('leaves collapsible markers inside fenced code untouched', () => {
+			expect(prepareOxContentMarkdown('```md\n+++ More\n```\n+++ Real\nbody\n+++')).toBe(
+				'```md\n+++ More\n```\n<details><summary><span class="details-marker"></span>Real</summary>\nbody\n</details>',
+			);
+		});
+
+		it('converts bare URLs to markdown links', () => {
+			expect(prepareOxContentMarkdown('> https://example.com/a(1).')).toBe(
+				'> [https://example.com/a(1)](https://example.com/a%281%29).',
+			);
+		});
+
+		it('leaves existing markdown links untouched when converting bare URLs', () => {
+			expect(prepareOxContentMarkdown('[site](https://example.com)')).toBe('[site](https://example.com)');
+		});
+
 		it('leaves malformed preview links untouched', () => {
 			expect(prepareOxContentMarkdown('[@preview](https://%)')).toBe('[@preview](https://%)');
 		});
@@ -400,6 +575,26 @@ if (import.meta.vitest != null) {
 			expect(html).toContain('<details>');
 			expect(html).toContain('<summary>More</summary>');
 			expect(html).toContain('body');
+			expect(html).toContain('</details>');
+		});
+
+		it('renders collapsible block contents as parsed markdown inside details', async () => {
+			const html = await renderMarkdown('+++ More\n\n## Hidden\n\nbody\n+++');
+
+			expect(html).toContain('<details>');
+			expect(html).toContain('<summary><span class="details-marker"></span>More</summary>');
+			expect(html).toContain('<h2 id="hidden">Hidden<a class="header-anchor" href="#hidden" aria-hidden="true" tabindex="-1">#</a></h2>');
+			expect(html).toContain('</details>');
+		});
+
+		it('renders the recap appendix as a closed details block', async () => {
+			const html = await renderMarkdown('## おまけ\n\n+++ おまけ\n\n## Bun\n\n`ccusage`は偉大。\n\n+++');
+
+			expect(html).toContain('<h2 id="おまけ">おまけ<a class="header-anchor" href="#おまけ" aria-hidden="true" tabindex="-1">#</a></h2>');
+			expect(html).toContain('<details>');
+			expect(html).toContain('<summary><span class="details-marker"></span>おまけ</summary>');
+			expect(html).toContain('<h2 id="bun">Bun<a class="header-anchor" href="#bun" aria-hidden="true" tabindex="-1">#</a></h2>');
+			expect(html).toContain('<code>ccusage</code>');
 			expect(html).toContain('</details>');
 		});
 	});

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -3,7 +3,12 @@ import { mergeHighlightedCodeBlocks, parseAndRender } from '@ox-content/napi';
 import { rendererRich, transformerTwoslash } from '@shikijs/twoslash';
 import { codeToHtml } from 'shiki';
 import { slugify } from '../lib/slugify.server.ts';
+import { applyBudouxHtml } from './budoux.ts';
+import { transformCollapsibleBlocks } from './collapsible.ts';
 import { addExternalLinkAttributes, escapeHtml } from './html.ts';
+import { replaceImageFigures } from './image-figures.ts';
+import { replaceLinkPreviews } from './link-preview.ts';
+import { normalizeAngleLinks, replaceBareUrls } from './linkify.ts';
 import { renderMagicLink } from './magic-link.ts';
 import { transformerEscape } from './shiki-transformer.ts';
 
@@ -29,12 +34,6 @@ type OpenCodeBlock = {
 type FenceLine = {
 	marker: string;
 	info: string;
-};
-
-type CollapsibleMarker = {
-	marker: string;
-	title: string;
-	open: boolean;
 };
 
 async function highlightCode(code: string, lang: string) {
@@ -80,103 +79,6 @@ function transformOutsideFences(content: string, transform: (line: string) => st
 	}).join('\n');
 }
 
-function parseCollapsibleMarker(line: string): CollapsibleMarker | null {
-	let indent = 0;
-	while (indent < line.length && line[indent] === ' ') {
-		indent += 1;
-	}
-
-	if (indent > 3) {
-		return null;
-	}
-
-	const rest = line.slice(indent);
-	let markerLength = 0;
-	while (markerLength < rest.length && rest[markerLength] === '+') {
-		markerLength += 1;
-	}
-
-	if (markerLength < 2) {
-		return null;
-	}
-
-	const open = rest[markerLength] === '>';
-	if (markerLength < 3 && !open) {
-		return null;
-	}
-
-	const marker = `${'+'.repeat(markerLength)}${open ? '>' : ''}`;
-	return {
-		marker,
-		title: rest.slice(marker.length).trim(),
-		open,
-	};
-}
-
-function renderCollapsibleSummary(title: string) {
-	return `<summary><span class="details-marker"></span>${escapeHtml(title)}</summary>`;
-}
-
-function transformCollapsibleBlocks(content: string) {
-	const lines = content.split('\n');
-	const markerStack: string[] = [];
-	let inFence = false;
-	let fenceMarker = '';
-	let inScript = false;
-
-	return lines.map((line) => {
-		const trimmed = line.trimStart();
-		const fence = trimmed.match(/^(`{3,}|~{3,})/)?.[1];
-
-		if (inScript) {
-			if (trimmed === '</script>') {
-				inScript = false;
-			}
-			return line;
-		}
-
-		if (/^<script(?:\s|>)/.test(trimmed)) {
-			inScript = true;
-			return line;
-		}
-
-		if (fence != null) {
-			if (!inFence) {
-				inFence = true;
-				fenceMarker = fence;
-			}
-			else if (trimmed.startsWith(fenceMarker[0]) && fence.length >= fenceMarker.length) {
-				inFence = false;
-				fenceMarker = '';
-			}
-
-			return line;
-		}
-
-		if (inFence) {
-			return line;
-		}
-
-		const collapsible = parseCollapsibleMarker(line);
-		if (collapsible == null) {
-			return line;
-		}
-
-		if (collapsible.title.length === 0) {
-			const lastMarker = markerStack.at(-1);
-			if (lastMarker !== collapsible.marker) {
-				return line;
-			}
-
-			markerStack.pop();
-			return '</details>';
-		}
-
-		markerStack.push(collapsible.marker);
-		return `<details${collapsible.open ? ' open' : ''}>${renderCollapsibleSummary(collapsible.title)}`;
-	}).join('\n');
-}
-
 function escapeMagicLinkUnderscores(line: string) {
 	return line.replace(/\{([^{}\n]+)\}/g, (match, input: string) => {
 		if (renderMagicLink(input) == null) {
@@ -187,87 +89,11 @@ function escapeMagicLinkUnderscores(line: string) {
 	});
 }
 
-function normalizeAngleUrl(url: string) {
-	return url.replace(/\(/g, '%28').replace(/\)/g, '%29');
-}
-
-function normalizeAngleLinks(line: string) {
-	return line
-		.replace(/\[([^\]]+)\]\(<(https?:\/\/[^>\s]+)>\)/g, (_match, label: string, url: string) => `[${label}](${normalizeAngleUrl(url)})`)
-		.replace(/<(https?:\/\/[^>\s]+)>/g, (_match, url: string) => `[${url}](${normalizeAngleUrl(url)})`);
-}
-
-function renderLinkPreview(url: string) {
-	if (!/^https?:\/\//.test(url)) {
-		return null;
-	}
-
-	try {
-		const parsed = new URL(url);
-		const escapedUrl = escapeHtml(url);
-		return `<div class="link-preview-widget"><a href="${escapedUrl}" rel="noopener" target="_blank"><div class="link-preview-widget-title">${escapeHtml(url)}</div><div class="link-preview-widget-url">${escapeHtml(parsed.hostname)}</div></a></div>`;
-	}
-	catch {
-		return null;
-	}
-}
-
-function replaceLinkPreviews(line: string) {
-	return line.replace(/\[@preview\]\((https?:\/\/[^)\s]+)\)/g, (match, url: string) => renderLinkPreview(url) ?? match);
-}
-
-function renderImageFigure(alt: string, src: string, title: string) {
-	return `<figure><img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}" title="${escapeHtml(title)}" loading="lazy" decoding="async"><figcaption>${escapeHtml(title)}</figcaption></figure>`;
-}
-
-const trailingBareUrlPunctuationPattern = /[),.:;!?]+$/;
-
-function shouldTrimTrailingBareUrlPunctuation(url: string) {
-	const last = url.at(-1);
-	if (last == null) {
-		return false;
-	}
-
-	if (last !== ')') {
-		return trailingBareUrlPunctuationPattern.test(last);
-	}
-
-	const openingParens = (url.match(/\(/g) ?? []).length;
-	const closingParens = (url.match(/\)/g) ?? []).length;
-	return closingParens > openingParens;
-}
-
-function normaliseBareUrlLink(url: string) {
-	let linkUrl = url;
-	let trailingPunctuation = '';
-
-	while (shouldTrimTrailingBareUrlPunctuation(linkUrl)) {
-		trailingPunctuation = `${linkUrl.at(-1)}${trailingPunctuation}`;
-		linkUrl = linkUrl.slice(0, -1);
-	}
-
-	const normalisedLinkUrl = normalizeAngleUrl(linkUrl);
-	return `[${linkUrl}](${normalisedLinkUrl})${trailingPunctuation}`;
-}
-
-function replaceBareUrls(line: string) {
-	if (line.includes('`') || line.includes('<') || line.includes('](')) {
-		return line;
-	}
-
-	return line.replace(/(^|[\s([>])(https?:\/\/[^\s<]+)/g, (_match, prefix: string, url: string) => {
-		return `${prefix}${normaliseBareUrlLink(url)}`;
-	});
-}
-
 function prepareOxContentMarkdown(content: string) {
 	return transformOutsideFences(
 		transformCollapsibleBlocks(content),
 		(line) => {
-			const preparedLine = replaceLinkPreviews(normalizeAngleLinks(escapeMagicLinkUnderscores(line))).replace(
-				/!\[([^\]]*)\]\((\S+)\s+(['"])(.*?)\3\)(?:\{[^}\n]+\})?/g,
-				(_match, alt: string, src: string, _quote: string, title: string) => renderImageFigure(alt, src, title),
-			);
+			const preparedLine = replaceImageFigures(replaceLinkPreviews(normalizeAngleLinks(escapeMagicLinkUnderscores(line))));
 
 			return replaceBareUrls(preparedLine);
 		},
@@ -455,7 +281,7 @@ export async function renderMarkdown(content: string) {
 		throw new Error(`ox-content failed to render Markdown: ${result.errors.join('\n')}`);
 	}
 
-	return postprocessRenderedHtml(mergeHighlightedCodeBlocks(result.html, await renderHighlightedCodeBlocks(prepared, result.html)));
+	return applyBudouxHtml(postprocessRenderedHtml(mergeHighlightedCodeBlocks(result.html, await renderHighlightedCodeBlocks(prepared, result.html))));
 }
 
 if (import.meta.vitest != null) {
@@ -559,6 +385,13 @@ if (import.meta.vitest != null) {
 			expect(html).toContain('ox-callout');
 			expect(html).toContain('ox-callout--warning');
 			expect(html).toContain('Be careful');
+		});
+
+		it('applies markdown-it-budoux compatible paragraph rendering', async () => {
+			const html = await renderMarkdown('今日は天気です。');
+
+			expect(html).toContain('<p style="word-break:keep-all;overflow-wrap:anywhere;">');
+			expect(html).toContain('今日は\u200B天気です。');
 		});
 
 		it('keeps syntax highlighted code blocks', async () => {

--- a/src/routes/blog/[slug]/prose.css
+++ b/src/routes/blog/[slug]/prose.css
@@ -1,5 +1,5 @@
 .prose figure figcaption {
-	color: var(--color-text-400);
+	color: #808080;
 	font-size: 0.875em;
 	line-height: 1.4285714;
 	margin-top: 0.8571429em;
@@ -25,7 +25,7 @@ html.dark .shiki span {
 
 html:not(.dark) .shiki {
 	color: var(--shiki-light) !important;
-	background-color: var(--color-text-150) !important;
+	background-color: #fafafa !important;
 }
 
 @media (prefers-contrast: more) {
@@ -62,17 +62,17 @@ html:not(.dark) .shiki {
 }
 
 .prose .footnote-ref a {
-	color: var(--color-text-400);
+	color: #808080;
 	text-decoration: none;
 }
 
 .prose .footnote-ref a:hover {
-	color: var(--color-text-600);
+	color: #262626;
 	text-decoration: underline;
 }
 
 .prose .footnotes {
-	color: var(--color-text-400);
+	color: #808080;
 	font-size: 0.95em;
 }
 
@@ -95,7 +95,7 @@ html:not(.dark) .shiki {
 }
 
 .prose .footnote-backref {
-	color: var(--color-text-400);
+	color: #808080;
 	width: 0.9em;
 	height: 0.9em;
 	display: inline-block;
@@ -105,6 +105,6 @@ html:not(.dark) .shiki {
 }
 
 .prose .footnote-backref:hover {
-	color: var(--color-text-500);
+	color: #4d4d4d;
 	opacity: 1;
 }

--- a/src/styles/prose-theme.css
+++ b/src/styles/prose-theme.css
@@ -1,7 +1,11 @@
 .prose {
-	--tw-prose-code: var(--color-text-800);
-	--tw-prose-invert-code: var(--color-text-100);
+	--tw-prose-code: #0f0f0f;
+	--tw-prose-invert-code: #ffffff;
 	--tw-prose-hr: #7d7d7d4d;
 	--tw-prose-th-borders: #7d7d7d4d;
 	--tw-prose-td-borders: #7d7d7d4d;
+}
+
+html.dark .prose {
+	--tw-prose-code: #ffffff;
 }


### PR DESCRIPTION
## Summary

Restores blog rendering behaviours that regressed after the markdown-exit to ox-content migration.

## What Changed

- Restored collapsible `+++` blocks, bare URL linkification, angle-link normalisation, preview cards, image figures, and magic-link underscore handling around ox-content.
- Split ox-content compatibility transforms into focused files under `src/markdown/` instead of keeping everything in `render.ts`.
- Restored markdown-it-budoux-compatible Japanese paragraph rendering with direct `budoux` usage.
- Restored pre-Tailwind prose colour values for inline code, captions, Shiki light backgrounds, and footnotes so dark-mode inline code stays visible.

## Testing

- `pnpm test -- src/markdown`
- `pnpm lint`
- `pnpm check`
- `pnpm build`

@coderabbitai please review this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores pre-migration blog markdown rendering: collapsible +++ blocks, linkification, Japanese segmentation, and prose colors for readability after moving to `@ox-content/napi`.

- Bug Fixes
  - Brought back collapsible `+++`/`++>` blocks, bare URL linkification (with parentheses normalization), preview cards, image figures, and magic-link underscore handling.
  - Restored Japanese paragraph segmentation and line-break styling using `budoux` (zero‑width spaces; keep-all), while skipping code/script/style and preserving HTML entities.
  - Unwraps paragraphs around Svelte components and link-preview widgets even when paragraphs have attributes.
  - Fixed prose theme regressions: dark-mode inline code color, figure captions, footnotes, and Shiki light background.

- Refactors
  - Moved `@ox-content` compatibility transforms into focused modules under `src/markdown/` (collapsible, linkify, link previews, image figures, Budoux) to keep `render.ts` small and clearer.

<sup>Written for commit f795766fbadd994d5e84ffa2aff19076d9cf41c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible expandable content blocks for markdown
  * Added link preview cards for enhanced link display
  * Improved automatic image rendering with figure elements
  * Enhanced URL handling with automatic bare URL linking and angle-bracket normalization
  * Added Japanese text line segmentation support

* **Style**
  * Updated color values across prose and code block styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->