### PR TITLE
chore(deps): enable pnpm pacquet installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"version": "0.0.1",
 	"private": true,
-	"packageManager": "pnpm@11.1.1",
+	"packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
 	"engines": {
 		"runtime": [
 			{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,79 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies:
+      '@pnpm/pacquet':
+        specifier: 0.11.1
+        version: 0.11.1
+
+packages:
+
+  '@pacquet/darwin-arm64@0.11.1':
+    resolution: {integrity: sha512-BuXwCsOvaZgEttK7VBZi4AADHRN+JofG3X5c+hklkTGrb2S3EiSQvY5eqfAekrZaRt9jd62KQDyvzAKRnSaEng==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pacquet/darwin-x64@0.11.1':
+    resolution: {integrity: sha512-Zq7uBkJdDihDfOicYFswF+yZSCEMCJByYH2H1Ik1cINC9HYBfBPp1x6EoVSFUUQghxVPwiaBjfDogCJEpZc2QA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pacquet/linux-arm64@0.11.1':
+    resolution: {integrity: sha512-4W3mJkC8ngzF04xEHvf8TAxaOeT9jzKtNp+8GJ1L1q/F0CNsMoiVEP+gB3fDwktcPyqJKU50UWlCQA7lACbaFg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pacquet/linux-x64@0.11.1':
+    resolution: {integrity: sha512-BGo9N02QUx6BhEZkuT1uFkEAzfDR7yZy1Cf6Ry0sTXVie593WLiSktNPFIGd1b3QGKXpgQylsXIigA5LC/P1/g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pacquet/win32-arm64@0.11.1':
+    resolution: {integrity: sha512-nDivP7M/GozAcqIJQQmgnpBAXgrQpVYuQIMhNbryNFkYYZsvHgnbbIhUpYRvosCn10XSYESNxh70wz5vAx/3WQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pacquet/win32-x64@0.11.1':
+    resolution: {integrity: sha512-5bl8i0jkWltwwhBmAqNDumh8uPdk1NBiHqCJfC4F+A3QZt6YQnFmszLkXu/uG1mzpO41dSUfEhQy/h4t2Y0Eaw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@pnpm/pacquet@0.11.1':
+    resolution: {integrity: sha512-4785guig8RpbPh5HCQFeyV6jyO7F6gPs/HxbcX9c6DK2ATwF7Awc24JCddOpxWIpzgiieBWyqhAKjTdCLK9E0A==}
+
+snapshots:
+
+  '@pacquet/darwin-arm64@0.11.1':
+    optional: true
+
+  '@pacquet/darwin-x64@0.11.1':
+    optional: true
+
+  '@pacquet/linux-arm64@0.11.1':
+    optional: true
+
+  '@pacquet/linux-x64@0.11.1':
+    optional: true
+
+  '@pacquet/win32-arm64@0.11.1':
+    optional: true
+
+  '@pacquet/win32-x64@0.11.1':
+    optional: true
+
+  '@pnpm/pacquet@0.11.1':
+    optionalDependencies:
+      '@pacquet/darwin-arm64': 0.11.1
+      '@pacquet/darwin-x64': 0.11.1
+      '@pacquet/linux-arm64': 0.11.1
+      '@pacquet/linux-x64': 0.11.1
+      '@pacquet/win32-arm64': 0.11.1
+      '@pacquet/win32-x64': 0.11.1
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,3 +34,6 @@ trustPolicy: no-downgrade
 
 trustPolicyExclude:
   - chokidar@4.0.3
+
+configDependencies:
+  '@pnpm/pacquet': 0.11.1


### PR DESCRIPTION
Upgrade the project package manager pin from pnpm 11.1.1 to 11.5.2 so Corepack consistently resolves a pnpm release that supports config dependencies.

Add @pnpm/pacquet as a pnpm config dependency and lock its platform packages. This enables the Rust install engine preview for dependency materialisation while keeping the package graph unchanged.

Validation: pnpm --version reports 11.5.2, pnpm install --frozen-lockfile --trust-lockfile uses pacquet successfully, and pnpm run check completes with existing Svelte warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pnpm` to 11.5.2 and enable the `@pnpm/pacquet` installer to use the Rust install engine for dependency materialization without changing the package graph. Corepack now resolves a `pnpm` version that supports config dependencies.

- **Dependencies**
  - Pin `packageManager` to `pnpm@11.5.2`.
  - Add `@pnpm/pacquet@0.11.1` as a config dependency and lock its platform packages.
  - Update `pnpm-lock.yaml` to include pacquet entries.

- **Migration**
  - No action needed; installs work as before.
  - Corepack will fetch `pnpm` 11.5.2. Running `pnpm install --frozen-lockfile --trust-lockfile` uses pacquet.

<sup>Written for commit 946d10e1f482cddf2806a251dfcdd0c618556b3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

