### PR TITLE
ci(nix): optimise setup action caching

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -10,8 +10,6 @@ runs:
       uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
       with:
         github_access_token: ${{ github.token }}
-        extra_nix_config: |
-          access-tokens = github.com=${{ github.token }}
 
     - name: Cache Nix store
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,24 +1,28 @@
 name: Setup Nix
-description: Install Nix and configure Cachix
+description: Install Nix and restore the Nix store from the GitHub Actions cache
 runs:
   using: composite
   steps:
+    - name: Setup takumi guard
+      uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+
     - name: Install Nix
       uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
       with:
         github_access_token: ${{ github.token }}
-
-    - name: Setup Cachix (numtide)
-      uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
-      with:
-        name: numtide
-        authToken: ''
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
 
     - name: Cache Nix store
       uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
       with:
-        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock') }}
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix') }}
         restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 3500000000
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-
+        purge-created: 172800
+        purge-primary-key: never
 
     - name: Load Nix development environment
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: read
 
 jobs:

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
               # Install dependencies only if node_modules/.pnpm/lock.yaml is older than pnpm-lock.yaml
               if [ ! -f node_modules/.pnpm/lock.yaml ] || [ pnpm-lock.yaml -nt node_modules/.pnpm/lock.yaml ]; then
                 echo "📦 Installing dependencies..."
-                pnpm install --frozen-lockfile
+                pnpm install --frozen-lockfile --config.confirmModulesPurge=false
               fi
 
               # Generate .env from .env.example if needed


### PR DESCRIPTION
Updates the shared Nix setup action to match the cache-backed setup used in ccusage, adjusted for this repository\047s smaller flake inputs.

The numtide Cachix setup is removed because this repo does not configure a numtide substituter, so the workflow now relies on the GitHub Actions Nix store cache. The cache key also includes flake.nix, GitHub-backed flake fetches get the workflow token, and cache purging is enabled so stale Nix caches do not accumulate.

Testing:
- nix develop --command pnpm run check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize CI Nix setup by removing the unused numtide Cachix step, switching to the GitHub Actions-backed Nix store cache, and making the dev shell `pnpm install` non-interactive to prevent CI prompts.

- **Refactors**
  - Remove `cachix/cachix-action` (numtide); use `nix-community/cache-nix-action` to restore/cache the Nix store.
  - Include `flake.nix` and `flake.lock` in the cache key; rely on `cachix/install-nix-action`’s `github_access_token` for GitHub-backed flake fetches (remove redundant token config).
  - Enable purging with a 3.5GB Linux store cap; set purge prefixes/retention; grant `actions: write` workflow permission.
  - Make dev-shell `pnpm install` non-interactive (`--config.confirmModulesPurge=false`) to avoid non-TTY prompts; add `flatt-security/setup-takumi-guard-npm` to the composite action.

<sup>Written for commit 5f3ce295963d837347ecd490ad7ea964ccd2d6ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

