### PR TITLE
fix(tweet): make prerender resilient to syndication API failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"@types/node": "^24.12.3",
 		"arktype": "^2.2.0",
 		"budoux": "^0.8.4",
+		"cockatiel": "^4.0.0",
 		"date-fns": "^4.1.0",
 		"diacritics": "^1.3.0",
 		"eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       budoux:
         specifier: ^0.8.4
         version: 0.8.4
+      cockatiel:
+        specifier: ^4.0.0
+        version: 4.0.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1589,6 +1592,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cockatiel@4.0.0:
+    resolution: {integrity: sha512-XpUZJnogsd03BGB19T9sv7Xb8SwvD8JddZV2Tlp0LNspopZ6Idv24ZwCl8vAGJ6JwODZ0zLRYVj3NWvmRcUDqA==}
+    engines: {node: '>=22'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4959,6 +4966,8 @@ snapshots:
   cloudflare-redirect-parser@1.0.0: {}
 
   clsx@2.1.1: {}
+
+  cockatiel@4.0.0: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/src/components/Tweet.remote.ts
+++ b/src/components/Tweet.remote.ts
@@ -1,6 +1,7 @@
 import { prerender } from '$app/server';
 import { error } from '@sveltejs/kit';
 import { type } from 'arktype';
+import { ExponentialBackoff, fallback, handleAll, retry } from 'cockatiel';
 import * as sveltweet from 'sveltweet/api';
 
 const getTweetPropsSchema = type({
@@ -20,6 +21,39 @@ type TweetLike = {
 	parent?: TweetLike;
 	quoted_tweet?: TweetLike;
 };
+
+type FetchedTweet = Awaited<ReturnType<typeof sveltweet.getTweet>>;
+
+/**
+ * Number of retries for the syndication API before falling back to the
+ * react-tweet API.
+ *
+ * The Twitter syndication API intermittently rate-limits requests during
+ * a full prerender build, so transient failures are retried a few times
+ * with an exponential backoff.
+ */
+const SYNDICATION_RETRIES = 2;
+
+/**
+ * Stable fallback endpoint for fetching tweets.
+ *
+ * The syndication API is unstable under load; this endpoint returns the
+ * same tweet payload wrapped as `{ data }`.
+ * @see https://react-tweet.vercel.app
+ */
+const REACT_TWEET_API = 'https://react-tweet.vercel.app/api/tweet';
+
+/**
+ * Retry policy for the syndication API.
+ *
+ * Retries transient failures with an exponential backoff (500ms initial
+ * delay), which usually outlasts the syndication API's intermittent rate
+ * limiting during a full prerender build.
+ */
+const syndicationRetry = retry(handleAll, {
+	maxAttempts: SYNDICATION_RETRIES,
+	backoff: new ExponentialBackoff({ initialDelay: 500 }),
+});
 
 /**
  * Backfill empty entity arrays on a tweet-like object.
@@ -47,11 +81,54 @@ function backfillEntities(tweet: TweetLike | null | undefined): void {
 }
 
 /**
+ * Fetch a tweet from the react-tweet API.
+ *
+ * Used as a fallback when the syndication API is unstable. Returns null
+ * when the tweet cannot be retrieved.
+ */
+async function fetchTweetFromReactTweet(id: string): Promise<FetchedTweet | null> {
+	const res = await fetch(`${REACT_TWEET_API}/${id}`);
+	if (!res.ok) {
+		return null;
+	}
+	const body = await res.json() as { data?: FetchedTweet };
+	return body.data ?? null;
+}
+
+/**
+ * Fetch a tweet resiliently.
+ *
+ * Retries the syndication API (via sveltweet) with a backoff, then falls
+ * back to the react-tweet API when it stays unstable. sveltweet's
+ * fetchTweet throws when the API returns a non-OK, non-404 response with a
+ * non-JSON body (typically a rate limit hit while prerendering many
+ * tweets). A clean undefined means the tweet is deleted/private, so it
+ * resolves without retrying or falling back. Returns null when the tweet
+ * cannot be fetched, so the caller can render a not-found state instead of
+ * failing the build.
+ */
+async function fetchTweetResilient(id: string): Promise<FetchedTweet | null> {
+	const fallbackToReactTweet = fallback<FetchedTweet | null>(handleAll, async () => {
+		try {
+			return await fetchTweetFromReactTweet(id);
+		}
+		catch (cause) {
+			console.warn(`Failed to fetch tweet ${id}:`, cause);
+			return null;
+		}
+	});
+
+	return fallbackToReactTweet.execute(
+		async () => syndicationRetry.execute(async () => await sveltweet.getTweet(id) ?? null),
+	);
+}
+
+/**
  * Remote function to fetch a tweet
  * @see https://svelte.dev/docs/kit/remote-functions
  */
 export const getTweet = prerender(getTweetPropsSchema, async ({ id }) => {
-	const tweet = await sveltweet.getTweet(id);
+	const tweet = await fetchTweetResilient(id);
 	if (tweet == null) {
 		error(404, `Tweet not found: ${id}`);
 	}

--- a/src/components/Tweet.svelte
+++ b/src/components/Tweet.svelte
@@ -11,6 +11,6 @@
 	<st.Tweet tweet={await getTweet({ id })} />
 
 	{#snippet failed()}
-		<a href='https://x.com/i/web/status/{id}' rel='noopener noreferrer' target='_blank'>Tweet {id}</a>
+		<st.TweetNotFound />
 	{/snippet}
 </svelte:boundary>


### PR DESCRIPTION
## Summary

The blog build was failing during prerender with `TypeError: Cannot read properties of undefined (reading 'error')` thrown from `sveltweet`'s `fetchTweet`, which 500'd the page prerender and failed the whole Cloudflare build.

## What changed

- Wrap the syndication fetch in a **cockatiel** retry policy with exponential backoff to ride out transient rate limiting during a full prerender.
- Fall back to the stable **react-tweet** API (`react-tweet.vercel.app/api/tweet/:id`) when the syndication API stays unstable.
- When the tweet still can't be fetched, throw `error(404)` so the `<svelte:boundary>` `failed` snippet renders `sveltweet`'s `TweetNotFound` component instead of crashing the build.
- Keep the top-level `await` so tweets are prerendered (an `{#await}` block would resolve client-side and not be in the static HTML).

## Why

`sveltweet`'s `fetchTweet` reads `data.error` when `data` is `undefined` — which happens on a non-OK, non-404 response with a non-JSON body (a rate limit hit while prerendering many tweets). The raw `TypeError` escaped as a 500 and `prerender.handleHttpError` rethrew it, failing the build.

## Testing

- `pnpm check` — 0 errors
- `pnpm lint` — clean
- `pnpm build` — prerenders successfully (including the previously-failing `2025-08-12-my-js-cli-stack-2025-en` post)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tweet prerender resilient to Twitter syndication API failures to stop builds from crashing. Retries `sveltweet` fetches, falls back to `react-tweet`, and returns 404 so the not-found UI renders instead of a 500.

- **Bug Fixes**
  - Retry `sveltweet.getTweet` with `cockatiel` exponential backoff to handle transient rate limits.
  - Fall back to `https://react-tweet.vercel.app/api/tweet/:id` when syndication stays unstable.
  - On failure, throw 404 so `<svelte:boundary>` renders `st.TweetNotFound` and the build continues.
  - Keep top-level await so tweets are prerendered into static HTML.

- **Dependencies**
  - Add `cockatiel@^4.0.0`.

<sup>Written for commit adc0abb412ea2f4dd3ca2f84f73f1fd0ae026019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

