### PR TITLE
fix(site): widen blog article body to fill the shell width

### DIFF
--- a/src/site/templates/Article.svelte
+++ b/src/site/templates/Article.svelte
@@ -31,7 +31,7 @@
 		<hr class='m-auto w-full max-w-100 opacity-25' />
 	</div>
 
-	<article class='prose mx-auto pb-8 text-text-700 dark:prose-invert dark:text-text-200'>
+	<article class='prose mx-auto max-w-none pb-8 text-text-700 dark:prose-invert dark:text-text-200'>
 		{@render content()}
 	</article>
 


### PR DESCRIPTION
## What

Add `max-w-none` to the blog article element so the post body uses the full shell width.

## Why

The article body was constrained to the Tailwind Typography `prose` default (`max-width: 65ch`), making it noticeably narrower than other pages (e.g. `works`) which fill the `max-w-4xl` shell container. This widens blog posts to match the rest of the site.

## Change

```diff
-<article class='prose mx-auto pb-8 ...'>
+<article class='prose mx-auto max-w-none pb-8 ...'>
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widen the blog article body to use the full shell width by adding `max-w-none` to the `prose` article element. This removes the default ~65ch limit and aligns post width with the rest of the site.

<sup>Written for commit 4bbb0fbb4b9844f23a75e428556ce9af97ca2628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated article content styling to allow the prose area to use the available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->