### PR TITLE
fix(site): keep blog table columns readable

### DIFF
--- a/src/styles/blog/prose.css
+++ b/src/styles/blog/prose.css
@@ -49,6 +49,27 @@
 	font-family: var(--font-code);
 }
 
+/*
+ * BudouX inserts zero-width spaces into every text node, so a numeric cell like
+ * "5,000人以上" can collapse to the width of "5,000" and wrap over three lines.
+ * Right-aligned columns are numeric by convention here, so keep them on one line.
+ */
+.prose table :is(th, td)[align='right'] {
+	white-space: nowrap;
+}
+
+/*
+ * Auto table layout hands the leftover width to whichever column has the most
+ * text, so a prose-heavy last column starves the row label down to its
+ * min-content width. Reserve a floor for the label column, but only where the
+ * remaining columns still have room to spare.
+ */
+@media (min-width: 48rem) {
+	.prose table :is(th, td):first-child {
+		min-width: 18ch;
+	}
+}
+
 .prose .footnote-ref {
 	font-size: 0.75em;
 	line-height: 0;


### PR DESCRIPTION
## What

Two CSS rules for `.prose` tables in blog articles.

1. Right-aligned (numeric) cells no longer wrap.
2. Above `48rem`, the first column gets a `min-width: 18ch` floor.

## Why

BudouX inserts zero-width spaces into every text node, so a numeric cell like `5,000人以上` could collapse to the width of `5,000` and wrap over three lines.

Auto table layout also hands the leftover width to whichever column has the most text, so a prose-heavy last column starves the row-label column down to its min-content width.

## Measured

On the 832px article body:

| | row-label column | tallest table height |
|---|---:|---:|
| before | 96px | 638px |
| after | 166px | 590px |

The widest existing table on the site (six columns, `2024-07-11-zenn-f535fa917121cc-ja`) keeps the same height and does not overflow, checked at both 832px and 704px container widths.

The `min-width` floor is behind a `48rem` media query so narrow viewports keep the current behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves blog table readability by preventing wraps in right‑aligned numeric cells and giving the first column a width floor on wide screens. Keeps labels readable and reduces table height without overflow.

- **Bug Fixes**
  - Prevent wrapping in right‑aligned cells to avoid `5,000人以上` splitting due to `BudouX` zero‑width spaces.
  - Add `min-width: 18ch` to the first column at `min-width: 48rem` so labels don’t collapse; widest existing table remains stable.

<sup>Written for commit daa0894b01319dbf296932e2b563b407d4334ad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

