### PR TITLE
feat(content): let posts import their components the way MDX does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,21 +76,30 @@ See `packages/content/src/blog/2024-10-12/index.md` for a full reference of avai
 
 ### Post-Specific Svelte Islands
 
-A post can use its own Svelte components without registering them anywhere. Put the component next to the post's `index.md` and reference it by file name:
+A post can use its own Svelte components without registering them anywhere. Put the component beside the post and import it the way MDX would:
 
 ```
 packages/content/src/blog/2026-07-23-example/
 ├── index.md
-└── SalesChart.svelte
+└── charts/
+    └── SalesChart.svelte
 ```
 
 ```md
+---
+title: Example
+---
+
+import SalesChart from './charts/SalesChart.svelte'
+
 <SalesChart title="Growth" bars={3} compact />
 ```
 
-- Only components in that post's own directory are available to it, so names cannot collide between posts. Single-file posts (`2026-07-23-example.md`) have no directory and therefore no islands.
+- Posts stay `.md`. The import line is the only MDX-shaped syntax supported — there are no JS expressions, no `export`, and no arbitrary JSX, so the file is still ordinary markdown and is served as-is at `/blog/<slug>.md`.
+- Only default imports of a relative `.svelte` path are recognised, and the path must stay inside the blog directory. The binding name is what the tag is called, so names are local to the post and cannot collide between posts.
+- Subdirectories are fine, which is how a component built from several files keeps them together.
 - Props follow the ox-content syntax: `prop="text"` is a string, `prop={42}` is JSON (numbers, booleans, objects, arrays), and a bare `prop` is `true`.
-- Unknown component tags are left in the output untouched, so a typo shows up in the page instead of silently disappearing.
+- Unknown component tags are left in the output untouched, and an import that resolves to nothing is left in the page as a literal line, so a typo shows up instead of silently disappearing.
 - Islands are server-rendered into the page and hydrated on the client, so their content is in the HTML without JS. Anything that only exists after mount (measured sizes, animations, timers) still needs a sensible server-rendered starting state.
 - Component-scoped CSS is linked from the page head for the islands a post uses, so a server-rendered island is styled before — and without — its JS. Svelte derives the scope class from the component path relative to `rootDir`, so `packages/content/scripts/build.ts` pins it to the workspace root to match the site build.
 - `Tweet` predates this mechanism and stays hand-wired because it is server-rendered from cached snapshots.

--- a/packages/content/src/blog.ts
+++ b/packages/content/src/blog.ts
@@ -4,7 +4,7 @@ import { matter } from 'gray-matter-es';
 import readingTime from 'reading-time';
 import { glob } from 'tinyglobby';
 import type { MarkdownRenderer } from './markdown-cache.ts';
-import { discoverPostIslands } from './islands.ts';
+import { resolvePostIslands } from './islands.ts';
 import { blogDirectory } from './paths.ts';
 import { loadOgpSnapshots } from './ogp-snapshots.ts';
 import { loadTweetSnapshots } from './tweet-snapshots.ts';
@@ -37,7 +37,7 @@ async function loadRenderOptions(content: string, filepath: string, directory: s
 	const [openGraph, tweets, islands] = await Promise.all([
 		loadOgpSnapshots(content, filepath),
 		loadTweetSnapshots(content, filepath),
-		discoverPostIslands(filepath, directory),
+		resolvePostIslands(content, filepath, directory),
 	]);
 	const hasIslands = Object.keys(islands).length > 0;
 	return openGraph == null && tweets == null && !hasIslands

--- a/packages/content/src/islands.ts
+++ b/packages/content/src/islands.ts
@@ -1,4 +1,4 @@
-import { access } from 'node:fs/promises';
+import { stat } from 'node:fs/promises';
 import path from 'node:path';
 import type { IslandModules } from './markdown/component-islands.ts';
 import { parseIslandImports } from './markdown/island-imports.ts';
@@ -11,8 +11,10 @@ import { blogDirectory } from './paths.ts';
  * are local to the post that declares them and cannot collide across posts.
  *
  * An import that points outside the blog directory or at a file that is not
- * there is dropped: the import line and the component tag both stay in the
- * rendered post, which shows the author the path is wrong.
+ * there is dropped, and so is a name two imports share, because there is no
+ * telling which of them the tags in the post meant. A dropped import keeps both
+ * its line and its component tag in the rendered post, which shows the author
+ * something is wrong.
  *
  * @param content - Markdown body, frontmatter already removed.
  * @param filepath - Absolute path of the post's markdown file.
@@ -28,8 +30,19 @@ export async function resolvePostIslands(
 	directory = blogDirectory(),
 ): Promise<IslandModules> {
 	const postDirectory = path.dirname(filepath);
+	const imports = parseIslandImports(content);
+	// A name bound twice cannot be resolved to one component, and picking either
+	// would silently drop the other import while its tags rendered as the one
+	// that won.
+	const duplicates = new Set(
+		imports.map(({ name }) => name).filter((name, index, names) => names.indexOf(name) !== index),
+	);
 	const resolved = await Promise.all(
-		parseIslandImports(content).map(async ({ name, specifier }) => {
+		imports.map(async ({ name, specifier }) => {
+			if (duplicates.has(name)) {
+				return null;
+			}
+
 			const absolute = path.resolve(postDirectory, specifier);
 			const moduleId = path.relative(directory, absolute).replaceAll(path.sep, '/');
 			// A specifier that climbs out of the blog directory would give the
@@ -39,7 +52,11 @@ export async function resolvePostIslands(
 			}
 
 			try {
-				await access(absolute);
+				// A directory can be named `Chart.svelte` and would pass an existence
+				// check, so the entry has to be a file the renderer can import.
+				if (!(await stat(absolute)).isFile()) {
+					return null;
+				}
 			} catch {
 				return null;
 			}
@@ -123,6 +140,54 @@ if (import.meta.vitest != null) {
 			);
 
 			expect(islands).toEqual({});
+		});
+
+		it('refuses a directory that happens to be named like a component', async () => {
+			const { createFixture } = await import('fs-fixture');
+			await using fixture = await createFixture({
+				'post/index.md': '# Post',
+				'post/Chart.svelte/keep.txt': '',
+			});
+			const islands = await resolvePostIslands(
+				"import Chart from './Chart.svelte'",
+				fixture.getPath('post/index.md'),
+				fixture.getPath(),
+			);
+
+			expect(islands).toEqual({});
+		});
+
+		it('drops a name that two imports bind', async () => {
+			const { createFixture } = await import('fs-fixture');
+			await using fixture = await createFixture({
+				'post/index.md': '# Post',
+				'post/A.svelte': '<p>a</p>',
+				'post/B.svelte': '<p>b</p>',
+			});
+			const islands = await resolvePostIslands(
+				"import Chart from './A.svelte'\nimport Chart from './B.svelte'",
+				fixture.getPath('post/index.md'),
+				fixture.getPath(),
+			);
+
+			expect(islands).toEqual({});
+		});
+
+		it('keeps the other imports when one name is duplicated', async () => {
+			const { createFixture } = await import('fs-fixture');
+			await using fixture = await createFixture({
+				'post/index.md': '# Post',
+				'post/A.svelte': '<p>a</p>',
+				'post/B.svelte': '<p>b</p>',
+				'post/Table.svelte': '<p>table</p>',
+			});
+			const islands = await resolvePostIslands(
+				"import Chart from './A.svelte'\nimport Chart from './B.svelte'\nimport Table from './Table.svelte'",
+				fixture.getPath('post/index.md'),
+				fixture.getPath(),
+			);
+
+			expect(islands).toEqual({ Table: 'post/Table.svelte' });
 		});
 
 		it('returns nothing for a post that imports no components', async () => {

--- a/packages/content/src/islands.ts
+++ b/packages/content/src/islands.ts
@@ -1,82 +1,141 @@
+import { access } from 'node:fs/promises';
 import path from 'node:path';
-import { glob } from 'tinyglobby';
 import type { IslandModules } from './markdown/component-islands.ts';
+import { parseIslandImports } from './markdown/island-imports.ts';
 import { blogDirectory } from './paths.ts';
 
 /**
- * Finds the Svelte components sitting next to a post so they can be used as
- * component tags in its markdown without being registered anywhere.
+ * Resolves a post's component imports to module ids the renderer can load.
  *
- * Only the post's own directory is searched, so a component belongs to the post
- * it is colocated with and names cannot collide across posts. Posts written as
- * a single `.md` file have no directory of their own and therefore no
- * components.
+ * The name a component is used under comes from the import binding, so names
+ * are local to the post that declares them and cannot collide across posts.
  *
+ * An import that points outside the blog directory or at a file that is not
+ * there is dropped: the import line and the component tag both stay in the
+ * rendered post, which shows the author the path is wrong.
+ *
+ * @param content - Markdown body, frontmatter already removed.
  * @param filepath - Absolute path of the post's markdown file.
  * @param directory - Blog source directory, used to build module ids.
  * @returns Component names mapped to module ids relative to the blog directory.
  * @example
- * await discoverPostIslands('/blog/2026-07-23-post/index.md');
- * // { GtvChart: '2026-07-23-post/GtvChart.svelte' }
+ * await resolvePostIslands(source, '/blog/2026-07-23-post/index.md');
+ * // { GtvChart: '2026-07-23-post/gtv-chart/GtvChart.svelte' }
  */
-export async function discoverPostIslands(
+export async function resolvePostIslands(
+	content: string,
 	filepath: string,
 	directory = blogDirectory(),
 ): Promise<IslandModules> {
-	if (path.basename(filepath) !== 'index.md') {
-		return {};
-	}
-
 	const postDirectory = path.dirname(filepath);
-	const files = await glob('*.svelte', { cwd: postDirectory, absolute: true });
+	const resolved = await Promise.all(
+		parseIslandImports(content).map(async ({ name, specifier }) => {
+			const absolute = path.resolve(postDirectory, specifier);
+			const moduleId = path.relative(directory, absolute).replaceAll(path.sep, '/');
+			// A specifier that climbs out of the blog directory would give the
+			// renderer a module id it cannot load, so refuse it here.
+			if (moduleId.startsWith('../') || path.isAbsolute(moduleId)) {
+				return null;
+			}
 
-	return Object.fromEntries(
-		files.map((file) => [
-			path.basename(file, '.svelte'),
-			path.relative(directory, file).replaceAll(path.sep, '/'),
-		]),
+			try {
+				await access(absolute);
+			} catch {
+				return null;
+			}
+
+			return [name, moduleId] as const;
+		}),
 	);
+
+	return Object.fromEntries(resolved.filter((entry) => entry != null));
 }
 
 if (import.meta.vitest != null) {
-	describe(discoverPostIslands, () => {
-		it('finds components colocated with the post', async () => {
+	describe(resolvePostIslands, () => {
+		it('resolves a component imported from the post directory', async () => {
 			const { createFixture } = await import('fs-fixture');
 			await using fixture = await createFixture({
-				'post/index.md': '# Post',
-				'post/GtvChart.svelte': '<p>chart</p>',
-				'post/gtv-chart-data.ts': 'export const data = [];',
+				'post/index.md': "import Chart from './Chart.svelte'",
+				'post/Chart.svelte': '<p>chart</p>',
 			});
-			const islands = await discoverPostIslands(
+			const islands = await resolvePostIslands(
+				"import Chart from './Chart.svelte'",
 				fixture.getPath('post/index.md'),
 				fixture.getPath(),
 			);
 
-			expect(islands).toEqual({ GtvChart: 'post/GtvChart.svelte' });
+			expect(islands).toEqual({ Chart: 'post/Chart.svelte' });
 		});
 
-		it('ignores components in sibling posts', async () => {
+		it('resolves a component from a subdirectory', async () => {
 			const { createFixture } = await import('fs-fixture');
 			await using fixture = await createFixture({
-				'first/index.md': '# First',
-				'second/index.md': '# Second',
-				'second/Chart.svelte': '<p>chart</p>',
+				'post/index.md': '# Post',
+				'post/chart/GtvChart.svelte': '<p>chart</p>',
 			});
-			const islands = await discoverPostIslands(
-				fixture.getPath('first/index.md'),
+			const islands = await resolvePostIslands(
+				"import GtvChart from './chart/GtvChart.svelte'",
+				fixture.getPath('post/index.md'),
+				fixture.getPath(),
+			);
+
+			expect(islands).toEqual({ GtvChart: 'post/chart/GtvChart.svelte' });
+		});
+
+		it('binds the component to the imported name', async () => {
+			const { createFixture } = await import('fs-fixture');
+			await using fixture = await createFixture({
+				'post/index.md': '# Post',
+				'post/Chart.svelte': '<p>chart</p>',
+			});
+			const islands = await resolvePostIslands(
+				"import Renamed from './Chart.svelte'",
+				fixture.getPath('post/index.md'),
+				fixture.getPath(),
+			);
+
+			expect(islands).toEqual({ Renamed: 'post/Chart.svelte' });
+		});
+
+		it('drops an import that points at a missing file', async () => {
+			const { createFixture } = await import('fs-fixture');
+			await using fixture = await createFixture({ 'post/index.md': '# Post' });
+			const islands = await resolvePostIslands(
+				"import Chart from './Chart.svelte'",
+				fixture.getPath('post/index.md'),
 				fixture.getPath(),
 			);
 
 			expect(islands).toEqual({});
 		});
 
-		it('returns nothing for a single-file post', async () => {
+		it('refuses a specifier that climbs out of the blog directory', async () => {
 			const { createFixture } = await import('fs-fixture');
 			await using fixture = await createFixture({
-				'post.md': '# Post',
-				'Chart.svelte': '<p>chart</p>',
+				'blog/post/index.md': '# Post',
+				'Outside.svelte': '<p>outside</p>',
 			});
-			const islands = await discoverPostIslands(fixture.getPath('post.md'), fixture.getPath());
+			const islands = await resolvePostIslands(
+				"import Outside from '../../Outside.svelte'",
+				fixture.getPath('blog/post/index.md'),
+				fixture.getPath('blog'),
+			);
+
+			expect(islands).toEqual({});
+		});
+
+		it('returns nothing for a post that imports no components', async () => {
+			const { createFixture } = await import('fs-fixture');
+			await using fixture = await createFixture({
+				'post/index.md': '# Post',
+				'post/Chart.svelte': '<p>chart</p>',
+			});
+			const islands = await resolvePostIslands(
+				'# Post',
+				fixture.getPath('post/index.md'),
+				fixture.getPath(),
+			);
 
 			expect(islands).toEqual({});
 		});

--- a/packages/content/src/markdown/fences.ts
+++ b/packages/content/src/markdown/fences.ts
@@ -1,0 +1,62 @@
+/**
+ * Applies a line transform to everything outside fenced code blocks.
+ *
+ * Fenced code is left untouched so a component tag or an import shown as an
+ * example in a code block stays literal instead of being rewritten.
+ *
+ * @param content - Markdown source.
+ * @param transform - Applied to each line outside a fence.
+ * @returns The markdown with the transform applied.
+ * @example
+ * transformOutsideFences('a\n```\nb\n```', (line) => line.toUpperCase());
+ * // 'A\n```\nb\n```'
+ */
+export function transformOutsideFences(
+	content: string,
+	transform: (line: string) => string,
+): string {
+	const lines = content.split('\n');
+	let inFence = false;
+	let fenceMarker = '';
+
+	return lines
+		.map((line) => {
+			const trimmed = line.trimStart();
+			const fence = trimmed.match(/^(`{3,}|~{3,})/)?.[1];
+
+			if (fence != null) {
+				if (!inFence) {
+					inFence = true;
+					fenceMarker = fence;
+				} else if (trimmed.startsWith(fenceMarker[0]) && fence.length >= fenceMarker.length) {
+					inFence = false;
+					fenceMarker = '';
+				}
+
+				return line;
+			}
+
+			return inFence ? line : transform(line);
+		})
+		.join('\n');
+}
+
+if (import.meta.vitest != null) {
+	describe(transformOutsideFences, () => {
+		it('transforms lines outside fences', () => {
+			expect(transformOutsideFences('a\nb', (line) => line.toUpperCase())).toBe('A\nB');
+		});
+
+		it('leaves fenced code untouched', () => {
+			expect(transformOutsideFences('a\n```\nb\n```\nc', (line) => line.toUpperCase())).toBe(
+				'A\n```\nb\n```\nC',
+			);
+		});
+
+		it('only closes a fence with a marker at least as long as the opener', () => {
+			expect(transformOutsideFences('````\na\n```\nb\n````\nc', (line) => line.toUpperCase())).toBe(
+				'````\na\n```\nb\n````\nC',
+			);
+		});
+	});
+}

--- a/packages/content/src/markdown/island-imports.ts
+++ b/packages/content/src/markdown/island-imports.ts
@@ -1,0 +1,132 @@
+import type { IslandModules } from './component-islands.ts';
+import { transformOutsideFences } from './fences.ts';
+
+/** A component a post pulls in with an import statement. */
+export type IslandImport = {
+	/** Name the component is bound to, used as the tag name in the body. */
+	name: string;
+	/** Specifier as written, relative to the post's own file. */
+	specifier: string;
+};
+
+// Deliberately narrower than JavaScript: a default import of a relative
+// `.svelte` path, bound to a capitalised name so it can be used as a tag.
+const IMPORT_PATTERN =
+	/^import\s+([A-Z][A-Za-z0-9]*)\s+from\s+(['"])(\.{1,2}\/[^'"]*\.svelte)\2\s*;?\s*$/;
+
+/**
+ * Reads the component imports a post declares.
+ *
+ * Anything that is not a default import of a relative `.svelte` path is
+ * ignored, so an unsupported import stays in the document where the author can
+ * see it rather than disappearing silently.
+ *
+ * @param content - Markdown body, frontmatter already removed.
+ * @returns One entry per import, in the order they appear.
+ * @example
+ * parseIslandImports("import Chart from './Chart.svelte'");
+ * // [{ name: 'Chart', specifier: './Chart.svelte' }]
+ */
+export function parseIslandImports(content: string): IslandImport[] {
+	const imports: IslandImport[] = [];
+
+	transformOutsideFences(content, (line) => {
+		const match = line.match(IMPORT_PATTERN);
+		if (match != null) {
+			imports.push({ name: match[1], specifier: match[3] });
+		}
+
+		return line;
+	});
+
+	return imports;
+}
+
+/**
+ * Removes the import statements that were resolved to a component.
+ *
+ * An import that resolved to nothing is left in place: the author sees the line
+ * in the rendered post and can tell the path is wrong, which matches how an
+ * unknown component tag stays visible.
+ *
+ * @param content - Markdown body.
+ * @param islands - Components that resolved, keyed by bound name.
+ * @returns The markdown with the resolved imports blanked out.
+ * @example
+ * stripIslandImports("import Chart from './Chart.svelte'\n", { Chart: 'post/Chart.svelte' });
+ * // '\n'
+ */
+export function stripIslandImports(content: string, islands: IslandModules): string {
+	return transformOutsideFences(content, (line) => {
+		const name = line.match(IMPORT_PATTERN)?.[1];
+		// Blanked rather than dropped so the line count is stable and the
+		// paragraph that follows keeps its separating blank line.
+		return name != null && islands[name] != null ? '' : line;
+	});
+}
+
+if (import.meta.vitest != null) {
+	describe(parseIslandImports, () => {
+		it('reads a default import of a relative component', () => {
+			expect(parseIslandImports("import Chart from './Chart.svelte'")).toEqual([
+				{ name: 'Chart', specifier: './Chart.svelte' },
+			]);
+		});
+
+		it('reads a component from a subdirectory', () => {
+			expect(parseIslandImports('import Chart from "./gtv-chart/GtvChart.svelte";')).toEqual([
+				{ name: 'Chart', specifier: './gtv-chart/GtvChart.svelte' },
+			]);
+		});
+
+		it('reads several imports in order', () => {
+			const content = "import B from './B.svelte'\nimport A from './A.svelte'";
+
+			expect(parseIslandImports(content).map((entry) => entry.name)).toEqual(['B', 'A']);
+		});
+
+		it('ignores an import inside a code fence', () => {
+			const content = "```md\nimport Chart from './Chart.svelte'\n```";
+
+			expect(parseIslandImports(content)).toEqual([]);
+		});
+
+		it('ignores a lowercase binding, which cannot be a tag', () => {
+			expect(parseIslandImports("import chart from './Chart.svelte'")).toEqual([]);
+		});
+
+		it('ignores a bare specifier', () => {
+			expect(parseIslandImports("import Chart from 'some-package/Chart.svelte'")).toEqual([]);
+		});
+
+		it('ignores an import of something other than a component', () => {
+			expect(parseIslandImports("import { rows } from './rows.ts'")).toEqual([]);
+		});
+
+		it('ignores a line that only mentions an import', () => {
+			expect(parseIslandImports("Write `import Chart from './Chart.svelte'` to use it.")).toEqual(
+				[],
+			);
+		});
+	});
+
+	describe(stripIslandImports, () => {
+		it('blanks an import that resolved', () => {
+			const content = "import Chart from './Chart.svelte'\n\n<Chart />";
+
+			expect(stripIslandImports(content, { Chart: 'post/Chart.svelte' })).toBe('\n\n<Chart />');
+		});
+
+		it('keeps an import that resolved to nothing', () => {
+			const content = "import Chart from './Missing.svelte'";
+
+			expect(stripIslandImports(content, {})).toBe(content);
+		});
+
+		it('keeps an import inside a code fence', () => {
+			const content = "```md\nimport Chart from './Chart.svelte'\n```";
+
+			expect(stripIslandImports(content, { Chart: 'post/Chart.svelte' })).toBe(content);
+		});
+	});
+}

--- a/packages/content/src/markdown/render.ts
+++ b/packages/content/src/markdown/render.ts
@@ -7,7 +7,9 @@ import { applyBudouxHtml } from './budoux.ts';
 import type { IslandModules } from './component-islands.ts';
 import { transformCollapsibleBlocks } from './collapsible.ts';
 import { replaceComponentIslands } from './component-islands.ts';
+import { transformOutsideFences } from './fences.ts';
 import { extractFootnotes, renderFootnotes } from './footnotes.ts';
+import { stripIslandImports } from './island-imports.ts';
 import { addExternalLinkAttributes, escapeHtml, unescapeHtml } from './html.ts';
 import { replaceImageFigures } from './image-figures.ts';
 import { replaceLinkPreviews } from './link-preview.ts';
@@ -43,33 +45,6 @@ export type RenderMarkdownOptions = {
 	tweets?: TweetSnapshots;
 };
 
-function transformOutsideFences(content: string, transform: (line: string) => string) {
-	const lines = content.split('\n');
-	let inFence = false;
-	let fenceMarker = '';
-
-	return lines
-		.map((line) => {
-			const trimmed = line.trimStart();
-			const fence = trimmed.match(/^(`{3,}|~{3,})/)?.[1];
-
-			if (fence != null) {
-				if (!inFence) {
-					inFence = true;
-					fenceMarker = fence;
-				} else if (trimmed.startsWith(fenceMarker[0]) && fence.length >= fenceMarker.length) {
-					inFence = false;
-					fenceMarker = '';
-				}
-
-				return line;
-			}
-
-			return inFence ? line : transform(line);
-		})
-		.join('\n');
-}
-
 function escapeMagicLinkUnderscores(line: string) {
 	return line.replace(/\{([^{}\n]+)\}/g, (match, input: string) => {
 		if (renderMagicLink(input) == null) {
@@ -81,7 +56,9 @@ function escapeMagicLinkUnderscores(line: string) {
 }
 
 function prepareOxContentMarkdown(content: string, islands: IslandModules = {}) {
-	return transformOutsideFences(transformCollapsibleBlocks(content), (line) => {
+	const body = stripIslandImports(transformCollapsibleBlocks(content), islands);
+
+	return transformOutsideFences(body, (line) => {
 		const embeds = replaceComponentIslands(
 			replaceNotByAIEmbeds(
 				line
@@ -565,6 +542,21 @@ if (import.meta.vitest != null) {
 			const html = await renderMarkdown('<Chart />');
 
 			expect(html).not.toContain('data-ox-island');
+		});
+
+		it('drops the import statement of a resolved component', async () => {
+			const html = await renderMarkdown("import Chart from './Chart.svelte'\n\n<Chart />", {
+				islands: { Chart: 'post/Chart.svelte' },
+			});
+
+			expect(html).toContain('data-ox-island="post/Chart.svelte"');
+			expect(html).not.toContain('import Chart');
+		});
+
+		it('keeps an import that resolved to nothing so the mistake is visible', async () => {
+			const html = await renderMarkdown("import Chart from './Missing.svelte'");
+
+			expect(html).toContain('import Chart');
 		});
 
 		it('applies markdown-it-budoux compatible paragraph rendering', async () => {


### PR DESCRIPTION
Stacked on #2087.

Components were discovered by globbing `*.svelte` beside the post and bound to their file name. That made the set of available components implicit, and the non-recursive glob meant a component built from several files could not live in its own directory — it needed a forwarding wrapper at the post root just to be reachable.

A post now names what it uses:

```md
---
title: Example
---

import SalesChart from './charts/SalesChart.svelte'

<SalesChart title="Growth" bars={3} compact />
```

## Scope

Posts stay `.md`. The import line is the only MDX-shaped syntax recognised — no JS expressions, no `export`, no arbitrary JSX. Calling the files `.mdx` would promise semantics the ox-content pipeline does not have, and the raw source is still served as ordinary markdown at `/blog/<slug>.md`.

Only default imports of a relative `.svelte` path are accepted, and the path must stay inside the blog directory.

## Behaviour

- The tag name comes from the import binding, so names stay local to the post that declares them and cannot collide between posts.
- Subdirectories work, which is the point: a component built from several files keeps them together instead of needing a wrapper.
- Imports inside fenced code blocks are ignored, so an example in a code block stays an example.
- An import that resolves to nothing — wrong path, missing file, or a specifier that climbs out of the blog directory — is left in the page as a literal line. That matches how an unknown component tag stays visible rather than silently disappearing.

`transformOutsideFences` moved out of `render.ts` into `markdown/fences.ts` so the import parser can share it.

`pnpm test` and `pnpm check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let posts import their Svelte islands with simple MDX-style imports while staying in `.md`. Components are explicit, support subdirectories, and invalid or ambiguous imports stay visible to surface mistakes.

- **New Features**
  - Support default imports of relative `.svelte` files inside the blog dir (e.g., `import SalesChart from './charts/SalesChart.svelte'`).
  - Tag names come from the binding and are local to the post; subdirectories are supported.
  - Imports inside code fences are ignored.
  - Resolved imports are stripped from the rendered HTML; unresolved, out-of-bounds, duplicate-name, or non-file (e.g., a directory named `.svelte`) imports remain as literal lines.

- **Refactors**
  - Replaced `discoverPostIslands` with `resolvePostIslands(content, filepath, directory)` in `packages/content/src/islands.ts`; updated `packages/content/src/blog.ts`.
  - Extracted `transformOutsideFences` to `packages/content/src/markdown/fences.ts`.
  - Added `packages/content/src/markdown/island-imports.ts` for parsing and stripping import lines; integrated in `packages/content/src/markdown/render.ts` to blank resolved imports.

<sup>Written for commit a92513572e83f4952f5eb5b7ae11aa3d733692f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Svelte components from nested directories within blog posts.
  * Added support for renamed component bindings and MDX-style default imports.
  * Component imports are automatically removed before rendering when resolved successfully.

* **Bug Fixes**
  * Prevented imports inside fenced code blocks from being altered.
  * Invalid, missing, duplicate, or out-of-directory imports remain visible for easier troubleshooting.

* **Documentation**
  * Documented supported import syntax, path requirements, and handling of unresolved imports and unknown tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->