### PR TITLE
fix(site): stack header nav in two rows on mobile

### DIFF
--- a/src/site/templates/Shell.svelte
+++ b/src/site/templates/Shell.svelte
@@ -65,25 +65,29 @@
 				</a>
 			{/if}
 		</div>
-		<nav class='flex w-full max-w-full flex-wrap gap-x-4 gap-y-4 text-lg font-bold max-md:mx-auto max-md:justify-center md:col-span-2 md:ml-auto md:mr-0 md:justify-end' aria-label='Primary navigation'>
-			{#each links as link (link.href)}
-				{@const active = pathname.startsWith('activePrefix' in link ? link.activePrefix : link.href)}
-				<a class='relative block shrink-0 whitespace-nowrap' href={link.href}>
-					<span>{link.label}</span>
-					<span class={`absolute left-0 top-full h-0.5 w-full ${active ? 'bg-accent-100' : 'bg-transparent'}`}></span>
+		<nav class='flex w-full max-w-full flex-col gap-x-4 gap-y-4 text-lg font-bold max-md:mx-auto max-md:items-center md:col-span-2 md:ml-auto md:mr-0 md:flex-row md:flex-wrap md:justify-end' aria-label='Primary navigation'>
+			<div class='flex flex-wrap justify-center gap-x-4 gap-y-4'>
+				{#each links as link (link.href)}
+					{@const active = pathname.startsWith('activePrefix' in link ? link.activePrefix : link.href)}
+					<a class='relative block shrink-0 whitespace-nowrap' href={link.href}>
+						<span>{link.label}</span>
+						<span class={`absolute left-0 top-full h-0.5 w-full ${active ? 'bg-accent-100' : 'bg-transparent'}`}></span>
+					</a>
+				{/each}
+			</div>
+			<div class='flex flex-wrap items-center justify-center gap-x-4 gap-y-4'>
+				<a class='relative block w-10 shrink-0 whitespace-nowrap px-0' href='/cv' rel='noopener noreferrer' target='_blank'>
+					<span class='fyc'>cv <span class='icon-[line-md--download-outline] size-[1em] shrink-0' aria-hidden='true'></span></span>
 				</a>
-			{/each}
-			<a class='relative block w-10 shrink-0 whitespace-nowrap px-0' href='/cv' rel='noopener noreferrer' target='_blank'>
-				<span class='fyc'>cv <span class='icon-[line-md--download-outline] size-[1em] shrink-0' aria-hidden='true'></span></span>
-			</a>
-			<div class='flex w-[4.375rem] justify-between [&_button]:my-auto [&_button]:flex [&_button]:cursor-pointer [&_button]:items-center [&_button]:border-0 [&_button]:bg-transparent [&_button]:p-0 [&_button]:text-inherit'>
-				<span class='flex items-center' data-dark-mode></span>
-				<a class='fyc my-auto' aria-label='RSS feed' href='/feed.xml'>
-					<span class='icon-[line-md--rss]' aria-hidden='true'></span><span class='sr-only'>RSS feed</span>
-				</a>
-				<a class='fyc my-auto' aria-label='Source code on GitHub' href='https://github.com/ryoppippi/ryoppippi.com' rel='noopener noreferrer' target='_blank'>
-					<span class='icon-[teenyicons--github-solid]' aria-hidden='true'></span><span class='sr-only'>Source code</span>
-				</a>
+				<div class='flex w-[4.375rem] justify-between [&_button]:my-auto [&_button]:flex [&_button]:cursor-pointer [&_button]:items-center [&_button]:border-0 [&_button]:bg-transparent [&_button]:p-0 [&_button]:text-inherit'>
+					<span class='flex items-center' data-dark-mode></span>
+					<a class='fyc my-auto' aria-label='RSS feed' href='/feed.xml'>
+						<span class='icon-[line-md--rss]' aria-hidden='true'></span><span class='sr-only'>RSS feed</span>
+					</a>
+					<a class='fyc my-auto' aria-label='Source code on GitHub' href='https://github.com/ryoppippi/ryoppippi.com' rel='noopener noreferrer' target='_blank'>
+						<span class='icon-[teenyicons--github-solid]' aria-hidden='true'></span><span class='sr-only'>Source code</span>
+					</a>
+				</div>
 			</div>
 		</nav>
 	</header>


### PR DESCRIPTION
Group the text links and the cv/utility icons into separate flex rows so narrow screens show works/blog/sponsors on the first row and cv, theme toggle, RSS and GitHub on the second. The md+ layout stays a single row.


Claude-Session: https://claude.ai/code/session_012bCjWVq1XoWfXfUqjv5gRf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On mobile, split the header nav into two rows to avoid wrapping: Works/Blog/Sponsors first; CV, theme toggle, RSS, and GitHub second. The md+ layout remains a single row.

<sup>Written for commit 958a1a30a6650841b080636941f672655ef4fa4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

