### PR TITLE
feat(site): add author profile page

### DIFF
--- a/src/site/about.ts
+++ b/src/site/about.ts
@@ -1,0 +1,71 @@
+import type { SiteAssets } from './assets.ts';
+import type { GeneratedFile } from './pages.ts';
+import { page, renderComponent } from './html.ts';
+import { author, authorStructuredData } from './author.ts';
+import About from './templates/About.svelte';
+
+const description =
+	'木村亮太朗（Ryotaro Kimura / @ryoppippi）のプロフィール。ccusageやSiteMCPなどを開発するソフトウェアエンジニア・OSS開発者です。';
+
+/**
+ * Renders the author profile page and its Person structured data.
+ *
+ * @param assets - Site assets used by the profile page.
+ * @returns The generated About page.
+ */
+export function aboutPage(assets: SiteAssets): GeneratedFile {
+	return {
+		path: 'about/index.html',
+		content: page({
+			title: `${author.japaneseName} / ${author.name}`,
+			pathname: '/about/',
+			content: renderComponent(About, {}),
+			description,
+			lang: 'ja',
+			assets,
+			style: 'about',
+			structuredData: {
+				'@context': 'https://schema.org',
+				'@type': 'ProfilePage',
+				'@id': `${author.pageUrl}#profile`,
+				url: author.pageUrl,
+				mainEntity: authorStructuredData,
+			},
+		}),
+	};
+}
+
+if (import.meta.vitest != null) {
+	const assets = {
+		base: '',
+		client: '',
+		islands: {},
+		pages: { about: '', article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
+		tweet: '',
+	} as const satisfies SiteAssets;
+
+	test('renders a visible bilingual identity and matching ProfilePage data', () => {
+		const generated = aboutPage(assets);
+		const jsonLd = generated.content.match(
+			/<script data-page-head type="application\/ld\+json">([\s\S]*?)<\/script>/,
+		)?.[1];
+
+		expect(generated.path).toBe('about/index.html');
+		expect(generated.content).toContain('<html lang="ja">');
+		expect(generated.content).toContain(author.japaneseName);
+		expect(generated.content).toContain(author.name);
+		expect(generated.content).toContain('view-transition-name---profile');
+		expect(JSON.parse(jsonLd ?? '')).toMatchObject({
+			'@context': 'https://schema.org',
+			'@type': 'ProfilePage',
+			url: author.pageUrl,
+			mainEntity: {
+				'@type': 'Person',
+				'@id': author.id,
+				name: author.name,
+				alternateName: [author.japaneseName, author.handle],
+				url: author.pageUrl,
+			},
+		});
+	});
+}

--- a/src/site/assets.ts
+++ b/src/site/assets.ts
@@ -1,4 +1,12 @@
-export const PAGE_STYLES = ['article', 'blog', 'error', 'home', 'sponsors', 'works'] as const;
+export const PAGE_STYLES = [
+	'about',
+	'article',
+	'blog',
+	'error',
+	'home',
+	'sponsors',
+	'works',
+] as const;
 
 export type PageStyle = (typeof PAGE_STYLES)[number];
 
@@ -31,6 +39,7 @@ export const DEV_ASSETS = {
 	base: '<link rel="stylesheet" href="/src/styles/fonts.css">\n\t<link rel="stylesheet" href="/src/site/style.css">',
 	client: '<script type="module" src="/src/site/client.ts"></script>',
 	pages: {
+		about: '<link rel="stylesheet" href="/src/site/styles/about.css">',
 		article: '<link rel="stylesheet" href="/src/site/styles/article.css">',
 		blog: '<link rel="stylesheet" href="/src/site/styles/blog.css">',
 		error: '<link rel="stylesheet" href="/src/site/styles/error.css">',
@@ -140,6 +149,7 @@ export function resolveSiteAssets(
 		client,
 		islands,
 		pages: {
+			about: stylesFor('/styles/about.css'),
 			article: stylesFor('/styles/article.css'),
 			blog: stylesFor('/styles/blog.css'),
 			error: stylesFor('/styles/error.css'),
@@ -215,6 +225,7 @@ if (import.meta.vitest != null) {
 			'post/Table.svelte': ['assets/Legend.css'],
 		},
 		pages: {
+			about: '<link href="/about.css">',
 			article: '<link href="/article.css">',
 			blog: '<link href="/blog.css">',
 			error: '<link href="/error.css">',
@@ -231,6 +242,9 @@ if (import.meta.vitest != null) {
 			const result = resolveSiteAssets(
 				'<link rel="stylesheet" href="/base.css"><script type="module" src="/client.js"></script>',
 				{
+					'src/site/styles/about.css': {
+						file: 'assets/about.css',
+					},
 					'src/site/styles/article.css': {
 						file: 'assets/article.css',
 					},
@@ -278,6 +292,7 @@ if (import.meta.vitest != null) {
 					'post/Chart.svelte': ['assets/Chart.css', 'assets/Legend.css'],
 				},
 				pages: {
+					about: '<link rel="stylesheet" crossorigin href="/assets/about.css">',
 					article: '<link rel="stylesheet" crossorigin href="/assets/article.css">',
 					blog: '<link rel="stylesheet" crossorigin href="/assets/blog.css">',
 					error: '<link rel="stylesheet" crossorigin href="/assets/error.css">',

--- a/src/site/author.ts
+++ b/src/site/author.ts
@@ -1,0 +1,30 @@
+import { siteOrigin } from './site-origin.ts';
+
+export const author = {
+	id: `${siteOrigin}/about/#person`,
+	pageUrl: `${siteOrigin}/about/`,
+	name: 'Ryotaro Kimura',
+	japaneseName: '木村亮太朗',
+	handle: '@ryoppippi',
+	imageUrl: `${siteOrigin}/ryoppippi.jpg`,
+	description:
+		'Software engineer and open-source developer building ccusage, SiteMCP, and other developer tools.',
+	sameAs: [
+		'https://github.com/ryoppippi',
+		'https://www.linkedin.com/in/ryoppippi/',
+		'https://x.com/ryoppippi',
+		'https://bsky.app/profile/ryoppippi.com',
+		'https://cv.ryoppippi.com',
+	],
+} as const;
+
+export const authorStructuredData = {
+	'@type': 'Person',
+	'@id': author.id,
+	name: author.name,
+	alternateName: [author.japaneseName, author.handle],
+	url: author.pageUrl,
+	image: author.imageUrl,
+	description: author.description,
+	sameAs: author.sameAs,
+} as const;

--- a/src/site/client.ts
+++ b/src/site/client.ts
@@ -335,6 +335,7 @@ function destroyPage(): void {
 
 function syncHead(next: Document): void {
 	document.title = next.title;
+	document.documentElement.lang = next.documentElement.lang;
 	for (const element of document.head.querySelectorAll('[data-page-head]')) {
 		element.remove();
 	}

--- a/src/site/dev-routes.ts
+++ b/src/site/dev-routes.ts
@@ -3,6 +3,7 @@ import type { SiteAssets } from './assets.ts';
 import type { PostListItem } from './content.ts';
 import type { OssProject, Talk } from './sections.ts';
 import { extractInstallSection, extractSection, parseStepCommands } from '../lib/dotfiles.ts';
+import { aboutPage } from './about.ts';
 import { postListItems } from './content.ts';
 import { articlePages, blogListPage, feed, homePage } from './pages.ts';
 import {
@@ -114,6 +115,9 @@ export async function renderDevRoute(
 	if (pathname === '/') {
 		return response(homePage(dependencies.assets).content);
 	}
+	if (pathname === '/about/') {
+		return response(aboutPage(dependencies.assets).content);
+	}
 	if (pathname.startsWith('/blog/')) {
 		return renderBlogRoute(pathname, dependencies);
 	}
@@ -174,7 +178,15 @@ if (import.meta.vitest != null) {
 				base: '',
 				client: '<script type="module" src="/src/site/client.ts"></script>',
 				islands: {},
-				pages: { article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
+				pages: {
+					about: '',
+					article: '',
+					blog: '',
+					error: '',
+					home: '',
+					sponsors: '',
+					works: '',
+				},
 				tweet: '',
 			},
 			loadBlogPost: vi.fn(async () => post),
@@ -239,6 +251,16 @@ if (import.meta.vitest != null) {
 			expect(loaders.loadBlogPostSource).toHaveBeenCalledWith('lazy-article');
 			expect(loaders.loadBlogPost).not.toHaveBeenCalled();
 		});
+	});
+
+	test('renders the About page without loading dynamic content', async () => {
+		const loaders = dependencies();
+
+		const result = await renderDevRoute('/about/', loaders);
+
+		expect(result?.body).toContain('木村亮太朗');
+		expect(loaders.loadBlogPost).not.toHaveBeenCalled();
+		expect(loaders.loadBlogPostMetadata).not.toHaveBeenCalled();
 	});
 
 	it('renders the site error page with a 404 status', () => {

--- a/src/site/generate.ts
+++ b/src/site/generate.ts
@@ -16,6 +16,7 @@ import {
 	rewriteContentAssetUrls,
 } from './content-assets.ts';
 import { loadExternalPosts } from './content.ts';
+import { aboutPage } from './about.ts';
 import { corePages } from './pages.ts';
 import {
 	errorPage,
@@ -84,6 +85,7 @@ export async function generateSite({
 	}));
 
 	const pages = [
+		aboutPage(assets),
 		...corePages(posts, externalPosts, assets),
 		ossPage(ossProjects, assets),
 		showcasePage(showcase, assets),
@@ -130,6 +132,7 @@ export async function generateSite({
 	await Promise.all(
 		[
 			'index.html',
+			'about/index.html',
 			'works/index.html',
 			'works/oss/index.html',
 			'works/showcase/index.html',

--- a/src/site/page-styles.ts
+++ b/src/site/page-styles.ts
@@ -4,6 +4,7 @@ type PageStyleLoader = () => Promise<unknown>;
 type PageStyleLoaders = Record<PageStyle, PageStyleLoader>;
 
 const pageStyleLoaders = {
+	about: () => import('./styles/about.css'),
 	article: () => import('./styles/article.css'),
 	blog: () => import('./styles/blog.css'),
 	error: () => import('./styles/error.css'),
@@ -78,6 +79,7 @@ if (import.meta.vitest != null) {
 			const article = vi.fn(async () => undefined);
 			const other = vi.fn(async () => undefined);
 			const loaders = {
+				about: other,
 				article,
 				blog: other,
 				error: other,
@@ -95,6 +97,7 @@ if (import.meta.vitest != null) {
 		it('ignores an unknown page style', async () => {
 			const loader = vi.fn(async () => undefined);
 			const loaders = {
+				about: loader,
 				article: loader,
 				blog: loader,
 				error: loader,

--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -9,6 +9,7 @@ import { page, renderComponent } from './html.ts';
 import Article from './templates/Article.svelte';
 import BlogList from './templates/BlogList.svelte';
 import Home from './templates/Home.svelte';
+import { authorStructuredData } from './author.ts';
 import { siteOrigin } from './site-origin.ts';
 
 type ArticleSeoMetadata = ArticleMetadata & { description: string };
@@ -53,6 +54,15 @@ export function homePage(assets: SiteAssets): GeneratedFile {
 			content: renderComponent(Home, {}),
 			assets,
 			style: 'home',
+			structuredData: {
+				'@context': 'https://schema.org',
+				'@type': 'WebSite',
+				'@id': `${siteOrigin}/#website`,
+				url: `${siteOrigin}/`,
+				name: 'ryoppippi.com',
+				alternateName: '@ryoppippi',
+				author: authorStructuredData,
+			},
 		}),
 	};
 }
@@ -109,7 +119,7 @@ export function articlePages(post: BlogPost, assets: SiteAssets): GeneratedFile[
 					description: metadata.description,
 					url,
 					mainEntityOfPage: { '@type': 'WebPage', '@id': url },
-					author: { '@type': 'Person', name: 'ryoppippi', url: siteOrigin },
+					author: authorStructuredData,
 					datePublished: post.pubDate,
 					inLanguage: post.lang,
 				},
@@ -160,7 +170,7 @@ if (import.meta.vitest != null) {
 		base: '',
 		client: '',
 		islands: {},
-		pages: { article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
+		pages: { about: '', article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
 		tweet: '',
 	} as const satisfies SiteAssets;
 

--- a/src/site/style.css
+++ b/src/site/style.css
@@ -28,3 +28,14 @@
 .dark::view-transition-new(root) {
 	z-index: 1;
 }
+
+::view-transition-group(name---profile) {
+	animation-duration: 600ms;
+	animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	::view-transition-group(name---profile) {
+		animation-duration: 0.01ms;
+	}
+}

--- a/src/site/styles/about.css
+++ b/src/site/styles/about.css
@@ -1,0 +1,5 @@
+@layer theme, base, components, utilities;
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+@reference '../../styles/tailwind.css';
+
+@source '../templates/About.svelte';

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -1,0 +1,91 @@
+<script lang='ts'>
+	import { author } from '../author.ts';
+
+	const projects = [
+		{
+			name: 'ccusage',
+			href: 'https://ccusage.com/',
+			description: 'Claude CodeやCodexなど、Coding Agentのトークン使用量と料金を集計するCLI。',
+		},
+		{
+			name: 'SiteMCP',
+			href: 'https://github.com/ryoppippi/sitemcp',
+			description: 'Webサイト全体を取得し、MCPサーバーとしてLLMへ渡すツール。',
+		},
+	] as const;
+
+	const links = [
+		{ label: 'GitHub', href: 'https://github.com/ryoppippi' },
+		{ label: 'CV', href: 'https://cv.ryoppippi.com' },
+		{ label: 'LinkedIn', href: 'https://www.linkedin.com/in/ryoppippi/' },
+		{ label: 'X', href: 'https://x.com/ryoppippi' },
+		{ label: 'Bluesky', href: 'https://bsky.app/profile/ryoppippi.com' },
+	] as const;
+</script>
+
+<article class='mx-auto max-w-3xl py-8 sm:py-16'>
+	<header class='grid items-center gap-8 md:grid-cols-[12rem_minmax(0,1fr)]'>
+		<img
+			class='mx-auto aspect-square size-40 rounded-full object-contain view-transition-name---profile md:size-48'
+			alt="{author.name}'s profile icon"
+			fetchpriority='high'
+			height='400'
+			loading='eager'
+			src='/ryoppippi.avif'
+			srcset='/ryoppippi-174.avif 174w, /ryoppippi-348.avif 348w, /ryoppippi.avif 400w'
+			sizes='(min-width: 48rem) 192px, 160px'
+			width='400'
+		/>
+		<div class='text-center md:text-left'>
+			<p class='text-lg font-medium text-text-500 dark:text-text-300'>{author.handle}</p>
+			<h1 class='mt-2 font-bold leading-tight'>
+				<span class='block text-4xl' lang='ja'>{author.japaneseName}</span>
+				<span class='mt-2 block text-2xl text-text-500 dark:text-text-300' lang='en'>{author.name}</span>
+			</h1>
+			<p class='mt-4 text-lg'>Software Engineer / OSS Developer</p>
+		</div>
+	</header>
+
+	<div class='mt-12 space-y-6 text-lg leading-8'>
+		<p lang='ja'>
+			木村亮太朗です。{author.handle}としてOSSを作っています。現在はイギリスでソフトウェアエンジニアとして働きながら、ccusageやSiteMCPなどを開発しています。
+		</p>
+		<p lang='en'>
+			I'm Ryotaro Kimura, a software engineer and open-source developer based in the UK. I build ccusage, SiteMCP, and other developer tools as @ryoppippi.
+		</p>
+		<p lang='ja'>
+			2026年にUK Global Talent Visa（Exceptional Talent）の承認を受けました。<a
+				class='underline decoration-accent-100 decoration-2 underline-offset-4'
+				href='/blog/2026-07-30-uk-gtv-ja/'
+			>申請の記録はこちらです。</a>
+		</p>
+	</div>
+
+	<section class='mt-14' aria-labelledby='about-projects'>
+		<h2 class='text-2xl font-bold' id='about-projects'>Projects</h2>
+		<div class='mt-5 grid gap-4 sm:grid-cols-2'>
+			{#each projects as project (project.name)}
+				<a
+					class='rounded-lg border border-base p-5 no-underline transition-base hover:scale-[1.02] hover:bg-[#88888811] hover:shadow-lg'
+					href={project.href}
+					rel='noopener noreferrer'
+					target='_blank'
+				>
+					<h3 class='text-xl font-bold'>{project.name}</h3>
+					<p class='mt-2 leading-7 text-text-500 dark:text-text-300'>{project.description}</p>
+				</a>
+			{/each}
+		</div>
+	</section>
+
+	<nav class='mt-12 flex flex-wrap gap-x-5 gap-y-3' aria-label='Profile links'>
+		{#each links as link (link.href)}
+			<a
+				class='font-medium underline decoration-accent-100 decoration-2 underline-offset-4'
+				href={link.href}
+				rel='me noopener noreferrer'
+				target='_blank'
+			>{link.label}</a>
+		{/each}
+	</nav>
+</article>

--- a/src/site/templates/Article.svelte
+++ b/src/site/templates/Article.svelte
@@ -1,11 +1,17 @@
 <script lang='ts'>
 	import { createRawSnippet } from 'svelte';
 	import type { BlogPost } from '@ryoppippi/content';
+	import { author } from '../author.ts';
 
 	let { date, pathname, post }: { date: string; pathname: string; post: BlogPost } = $props();
 	const markdownPath = $derived(`${pathname.slice(0, -1)}.md`);
 	const content = $derived(createRawSnippet(() => ({ render: () => post.html })));
 	const url = $derived(`https://ryoppippi.com${pathname}`);
+	const authorLabel = $derived(
+		post.lang === 'ja'
+			? `${author.japaneseName}（${author.handle}）`
+			: `${author.name} (${author.handle})`,
+	);
 	const blueskyUrl = $derived(`https://bsky.app/intent/compose?text=${encodeURIComponent(`Reading @ryoppippi.com's ${url}\n\nI think...`)}`);
 	const tweetUrl = $derived(`https://twitter.com/intent/tweet?text=${encodeURIComponent(`Reading @ryoppippi's ${url}\n\nI think...`)}`);
 </script>
@@ -24,6 +30,10 @@
 			<a class='opacity-70 hover:opacity-100' aria-label='Markdown source' href={markdownPath} rel='noopener noreferrer' target='_blank'>
 				<span class='icon-[ri--markdown-line] size-6 align-middle' aria-hidden='true'></span>
 			</a>
+		</p>
+		<p class='text-text-400'>
+			{post.lang === 'ja' ? '著者' : 'By'}
+			<a class='opacity-70 hover:opacity-100' href='/about/' rel='author'>{authorLabel}</a>
 		</p>
 	</hgroup>
 

--- a/src/site/templates/Home.svelte
+++ b/src/site/templates/Home.svelte
@@ -1,4 +1,6 @@
 <script lang='ts'>
+	import { author } from '../author.ts';
+
 	const socials = [
 		['icon-[line-md--github-loop]', 'GitHub profile', '/github'],
 		['icon-[ph--git-pull-request-duotone]', 'Recent pull requests', '/pr'],
@@ -11,23 +13,28 @@
 
 <article class='gcc container mx-auto mt-8'>
 	<div class='w-full animate-[root-flip-in-x_1s_both]'>
-		<img
-			class='mx-auto aspect-square w-1/2 rounded-full object-contain view-transition-name---profile md:size-64'
-			alt='ryoppippi'
-			fetchpriority='high'
-			height='400'
-			loading='eager'
-			src='/ryoppippi.avif'
-			srcset='/ryoppippi-174.avif 174w, /ryoppippi-348.avif 348w, /ryoppippi.avif 400w'
-			sizes='(min-width: 48rem) 256px, calc(50vw - 2rem)'
-			width='400'
-		/>
+		<a class='block' aria-label={`About ${author.japaneseName} / ${author.name}`} href='/about/'>
+			<img
+				class='mx-auto aspect-square w-1/2 rounded-full object-contain view-transition-name---profile md:size-64'
+				alt="{author.name}'s profile icon"
+				fetchpriority='high'
+				height='400'
+				loading='eager'
+				src='/ryoppippi.avif'
+				srcset='/ryoppippi-174.avif 174w, /ryoppippi-348.avif 348w, /ryoppippi.avif 400w'
+				sizes='(min-width: 48rem) 256px, calc(50vw - 2rem)'
+				width='400'
+			/>
+		</a>
 	</div>
 	<div class='mt-8'>
 		<h1 class='mb-6 text-center text-4xl font-bold' style='view-transition-name:title-ryoppippi'>
 			<span class='block sm:inline'>@ryoppippi</span>
 			<span class='animate-pulse text-center text-xl font-medium text-text-700 dark:text-text-200'>Engineer</span>
 		</h1>
+		<p class='text-center text-lg font-medium text-text-500 dark:text-text-300'>
+			<a href='/about/'><span lang='ja'>{author.japaneseName}</span> / <span lang='en'>{author.name}</span></a>
+		</p>
 	</div>
 </article>
 

--- a/src/site/templates/Shell.svelte
+++ b/src/site/templates/Shell.svelte
@@ -1,5 +1,6 @@
 <script lang='ts'>
 	import { createRawSnippet } from 'svelte';
+	import { author } from '../author.ts';
 	import { siteOrigin } from '../site-origin.ts';
 
 	let {
@@ -33,6 +34,7 @@
 	const pageContent = $derived(createRawSnippet(() => ({ render: () => content })));
 	const isHome = $derived(pathname === '/');
 	const links = [
+		{ href: '/about/', label: 'about' },
 		{ href: '/works/oss/', label: 'works', activePrefix: '/works/' },
 		{ href: '/blog/', label: 'blog' },
 		{ href: '/sponsors/', label: 'sponsors' },
@@ -51,7 +53,8 @@
 	{#each alternateLinks as alternate (alternate.lang)}
 		<link data-page-head rel='alternate' hreflang={alternate.lang} href={alternate.url} />
 	{/each}
-  <link rel="author" href="https://www.hatena.ne.jp/ryoppippi-2/" />
+	<meta data-page-head name='author' content={author.name} />
+	<link data-page-head rel='author' href={author.pageUrl} />
 	<meta data-page-head property='og:type' content={article ? 'article' : 'website'} />
 	<meta data-page-head property='og:title' content={fullTitle} />
 	<meta data-page-head property='og:description' content={description} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -123,8 +123,7 @@ export default defineConfig({
 					environment: 'node',
 					includeSource: [
 						'src/lib/**/*.ts',
-						'src/site/{assets,content-assets,dev-routes,dev-server}.ts',
-						'src/site/{generate,page-styles,pages,sitemap}.ts',
+						'src/site/{about,assets,content-assets,dev-routes,dev-server,generate,page-styles,pages,sitemap}.ts',
 						'packages/content/src/{artifact,blog,island-renderer,islands,ogp-snapshots,paths,tweet-snapshots}.ts',
 						'packages/content/src/blog/**/*.ts',
 						'packages/content/src/markdown/**/*.ts',


### PR DESCRIPTION
## Summary

- add a bilingual About page for Ryotaro Kimura / 木村亮太朗 with project and profile links
- connect the home page, article bylines, and JSON-LD to a single Person identity
- animate the profile icon between the home and About pages with a reduced-motion fallback
- preserve the generated document language during client-side navigation

## Testing

- pnpm check
- pnpm test (37 files, 215 tests)
- pnpm build
- cmux browser verification of the home-to-About transition, ProfilePage metadata, canonical URL, and console


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bilingual author profile page at /about/ and unifies site metadata around one Person. Previously there was no profile page, articles used an inline author, the root lang attribute didn’t update on client navigation, and the author link pointed to Hatena; now ProfilePage/WebSite/BlogPosting reference one Person, bylines and the home avatar link to /about/, the profile image animates between pages with a reduced-motion fallback, and navigation syncs document.lang.

- Routes/build: Generates `about/index.html` via `aboutPage`, serves it in dev, and loads the new `about` page style.
- Structured data: Introduces `authorStructuredData`; Home emits WebSite with `author`, Article uses the shared Person, About emits ProfilePage whose `mainEntity` is the same Person with `sameAs`.
- UI: Home avatar links to /about/; Article shows a localized “By” line linking to /about/; Shell sets `<meta name="author">` and `<link rel="author">` to the profile page (replaces the Hatena link).
- Runtime: Client updates `document.documentElement.lang` on navigation to preserve page language.
- CSS: Adds view-transition group for the profile image (`name---profile`) with a reduced-motion fallback; adds `src/site/styles/about.css`.
- Copy: Uses bilingual labels and `@ryoppippi` consistently across pages.

<sup>Written for commit b3e32f96e472b36e65f59c43ede20d96f476029f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated About page with the author’s profile, biography, projects, and social links.
  * Added About navigation links from the site shell, homepage profile, and article bylines.
  * Added structured metadata for the site and author to improve search presentation.
* **Bug Fixes**
  * Page language now stays synchronized during client-side navigation.
  * Added reduced-motion support for profile page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->