### PR TITLE
fix(seo): improve home search snippets

### DIFF
--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -64,7 +64,7 @@ export function homePage(assets: SiteAssets): GeneratedFile {
 		content: page({
 			title: '',
 			pathname: '/',
-			content: renderComponent(Home, {}),
+			content: renderComponent(Home, { description: HOME_DESCRIPTION }),
 			description: HOME_DESCRIPTION,
 			assets,
 			style: 'home',
@@ -219,6 +219,9 @@ if (import.meta.vitest != null) {
 		expect(html).toContain(
 			`<meta data-page-head="" name="description" content="${HOME_DESCRIPTION}">`,
 		);
+		expect(html.match(/<p data-home-description[^>]*>([^<]*)<\/p>/)?.[1]).toBe(HOME_DESCRIPTION);
+		expect(html).toMatch(/<span data-nosnippet(?:="")?><a class="skip-link"/);
+		expect(html).toMatch(/<div data-nosnippet(?:="")? class="flex flex-wrap justify-center/);
 		expect(html).toContain('<meta data-page-head="" property="og:title" content="ryoppippi.com">');
 		expect(html).toContain('"@type":"WebSite"');
 	});

--- a/src/site/templates/Home.svelte
+++ b/src/site/templates/Home.svelte
@@ -1,6 +1,8 @@
 <script lang='ts'>
 	import { SITE_ORIGIN } from '../consts.ts';
 
+	let { description }: { description: string } = $props();
+
 	const socials = [
 		['icon-[line-md--github-loop]', 'GitHub profile', '/github'],
 		['icon-[ph--git-pull-request-duotone]', 'Recent pull requests', '/pr'],
@@ -30,6 +32,7 @@
 			<span class='block sm:inline'>@ryoppippi</span>
 			<span class='animate-pulse text-center text-xl font-medium text-text-700 dark:text-text-200'>Engineer</span>
 		</h1>
+		<p data-home-description class='mx-auto max-w-2xl text-center text-base leading-relaxed text-text-700 dark:text-text-200'>{description}</p>
 	</div>
 </article>
 

--- a/src/site/templates/Shell.svelte
+++ b/src/site/templates/Shell.svelte
@@ -18,10 +18,10 @@
 	] as const;
 </script>
 
-<a class='skip-link' href='#main-content'>Skip to content</a>
+<span data-nosnippet><a class='skip-link' href='#main-content'>Skip to content</a></span>
 <div class='mx-auto my-3 max-w-4xl px-8'>
 	<header class='mx-auto grid items-center gap-y-6 py-6 text-xl opacity-70 transition-base hover:opacity-100 max-md:grid-cols-1 md:grid-cols-3'>
-		<div class={isHome ? 'max-md:hidden md:flex' : 'flex'}>
+		<div data-nosnippet class={isHome ? 'max-md:hidden md:flex' : 'flex'}>
 			{#if !isHome}
 				<a class='relative font-bold max-md:mx-auto md:mx-0' aria-label='Home' href='/'>
 					<span style='view-transition-name:title-ryoppippi'>@ryoppippi</span>
@@ -29,7 +29,7 @@
 			{/if}
 		</div>
 		<nav class='flex w-full max-w-full flex-col gap-x-4 gap-y-4 text-lg font-bold max-md:mx-auto max-md:items-center md:col-span-2 md:ml-auto md:mr-0 md:flex-row md:flex-wrap md:justify-end' aria-label='Primary navigation'>
-			<div class='flex flex-wrap justify-center gap-x-4 gap-y-4'>
+			<div data-nosnippet class='flex flex-wrap justify-center gap-x-4 gap-y-4'>
 				{#each links as link (link.href)}
 					{@const active = pathname.startsWith('activePrefix' in link ? link.activePrefix : link.href)}
 					<a class='relative block shrink-0 whitespace-nowrap' href={link.href}>
@@ -38,7 +38,7 @@
 					</a>
 				{/each}
 			</div>
-			<div class='flex flex-wrap items-center justify-center gap-x-4 gap-y-4'>
+			<div data-nosnippet class='flex flex-wrap items-center justify-center gap-x-4 gap-y-4'>
 				<a class='relative block w-10 shrink-0 whitespace-nowrap px-0' href='/cv' rel='noopener noreferrer' target='_blank'>
 					<span class='fyc'>cv <span class='icon-[line-md--download-outline] size-[1em] shrink-0' aria-hidden='true'></span></span>
 				</a>


### PR DESCRIPTION
Render the home-page description in the visible SSR content so search engines have a useful snippet candidate. Mark skip-link and navigation boilerplate with `data-nosnippet` to prevent Google from using menu text in search results, with regression coverage for the generated HTML.

Tested with `pnpm format`, `pnpm test src/site/pages.ts`, `pnpm build`, and browser verification of the rendered metadata, exclusions, and layout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves home-page search snippets by rendering the description as visible SSR content and excluding navigation boilerplate from Google snippets. Previously Google sometimes used menu text; now the home description is a primary snippet candidate while skip-link and nav are ignored.

- Renders a `<p data-home-description>` with `HOME_DESCRIPTION` in `Home.svelte`.
- Marks skip-link and key nav containers with `data-nosnippet` to prevent snippet selection.
- Adds regression tests validating the visible description and `data-nosnippet` markers.
- No UI or routing changes; impact is limited to search snippet behavior.

<sup>Written for commit fc17eea138f764524cb4bcc0f56b9c16a5bcbd0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

