### PR TITLE
feat(seo): generate Git-backed sitemap lastmod

### DIFF
--- a/src/site/generate.ts
+++ b/src/site/generate.ts
@@ -46,6 +46,16 @@ async function writeGeneratedFiles(outDir: string, files: GeneratedFile[]): Prom
 	}
 }
 
+/**
+ * Generates the static site and its auxiliary files.
+ *
+ * @param assets - Bundled site assets referenced by generated pages.
+ * @param content - Optional prebuilt content artifact.
+ * @param outDir - Directory that receives generated files.
+ * @param renderTweet - Tweet renderer used when content must be built locally.
+ * @param root - Repository root used for source loading and Git metadata.
+ * @returns A promise that resolves after all generated files are written.
+ */
 export async function generateSite({
 	assets,
 	content,

--- a/src/site/generate.ts
+++ b/src/site/generate.ts
@@ -17,6 +17,7 @@ import {
 } from './content-assets.ts';
 import { SITE_ORIGIN } from './consts.ts';
 import { loadExternalPosts } from './content.ts';
+import { gitLastModified } from './git-last-modified.ts';
 import { corePages } from './pages.ts';
 import {
 	errorPage,
@@ -121,10 +122,15 @@ export async function generateSite({
 		);
 	}
 
-	const urls = pages
-		.filter((file) => file.path.endsWith('.html') && file.path !== '404.html')
-		.map((file) => `${SITE_ORIGIN}/${file.path.replace(/(?:index)?\.html$/, '')}`);
-	plainFiles.push(sitemap(urls));
+	const urls = pages.filter((file) => file.path.endsWith('.html') && file.path !== '404.html');
+	const sitemapEntries = await Promise.all(
+		urls.map(async (file) => {
+			const loc = `${SITE_ORIGIN}/${file.path.replace(/(?:index)?\.html$/, '')}`;
+			const lastmod = await gitLastModified(root, file.sourcePaths ?? []);
+			return lastmod == null ? { loc } : { loc, lastmod };
+		}),
+	);
+	plainFiles.push(sitemap(sitemapEntries));
 	await writeGeneratedFiles(outDir, plainFiles);
 
 	await Promise.all(

--- a/src/site/git-last-modified.ts
+++ b/src/site/git-last-modified.ts
@@ -1,0 +1,55 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+function toGitPath(root: string, sourcePath: string): string | undefined {
+	const absoluteRoot = path.resolve(root);
+	const absolutePath = path.resolve(absoluteRoot, sourcePath);
+	const relativePath = path.relative(absoluteRoot, absolutePath);
+	return relativePath === '..' ||
+		relativePath.startsWith(`..${path.sep}`) ||
+		path.isAbsolute(relativePath)
+		? undefined
+		: relativePath;
+}
+
+/**
+ * Returns the latest Git commit timestamp for a set of source paths.
+ *
+ * @param root - Repository root used as the Git working directory.
+ * @param sourcePaths - Files or directories whose latest commit should be considered.
+ * @returns An ISO 8601 timestamp, or `undefined` when Git history is unavailable.
+ * @example
+ * ```ts
+ * const modified = await gitLastModified(process.cwd(), ['src/site/pages.ts']);
+ * ```
+ */
+export async function gitLastModified(
+	root: string,
+	sourcePaths: readonly string[],
+): Promise<string | undefined> {
+	const paths = sourcePaths
+		.map((sourcePath) => toGitPath(root, sourcePath))
+		.filter((sourcePath): sourcePath is string => sourcePath != null);
+	if (paths.length === 0) {
+		return undefined;
+	}
+
+	const revision = process.env.WORKERS_CI_COMMIT_SHA ?? process.env.CF_PAGES_COMMIT_SHA ?? 'HEAD';
+	try {
+		const { stdout } = await execFileAsync(
+			'git',
+			['-C', root, 'log', '-1', '--format=%cI', revision, '--', ...paths],
+			{ encoding: 'utf8' },
+		);
+		const timestamp = stdout.trim();
+		return timestamp.length === 0 || Number.isNaN(Date.parse(timestamp))
+			? undefined
+			: new Date(timestamp).toISOString();
+	} catch {
+		return undefined;
+	}
+}

--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -58,11 +58,20 @@ function articleImageUrl(html: string, articleUrl: string): string | undefined {
  * A file emitted by the static site generator.
  */
 export type GeneratedFile = {
+	/** Relative path below the generated site directory. */
 	path: string;
+	/** Serialized file contents. */
 	content: string;
+	/** Repository paths whose meaningful changes update the generated file. */
 	sourcePaths?: readonly string[];
 };
 
+/**
+ * Renders the site home page.
+ *
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated home page.
+ */
 export function homePage(assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'index.html',
@@ -87,12 +96,20 @@ export function homePage(assets: SiteAssets): GeneratedFile {
 	};
 }
 
+/**
+ * Renders the blog index page.
+ *
+ * @param items - Local and external posts to list.
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated blog index page.
+ */
 export function blogListPage(items: PostListItem[], assets: SiteAssets): GeneratedFile {
 	const sorted = items.toSorted((a, b) => b.pubDate.localeCompare(a.pubDate));
 	return {
 		path: 'blog/index.html',
 		sourcePaths: [
 			'src/site/content.ts',
+			'src/site/pages.ts',
 			'src/site/templates/BlogList.svelte',
 			'packages/content/src/blog',
 			'src/contents/external-rss/rss.json',
@@ -132,7 +149,7 @@ export function articlePages(post: BlogPost, assets: SiteAssets): GeneratedFile[
 	return [
 		{
 			path: `blog/${post.filename}/index.html`,
-			sourcePaths: [sourcePath],
+			sourcePaths: ['src/site/pages.ts', sourcePath],
 			content: page({
 				title: `${post.title} | blog`,
 				pathname,
@@ -164,6 +181,12 @@ export function articlePages(post: BlogPost, assets: SiteAssets): GeneratedFile[
 	];
 }
 
+/**
+ * Builds the RSS feed for published local posts.
+ *
+ * @param posts - Blog post metadata to include.
+ * @returns The generated RSS feed.
+ */
 export function feed(posts: BlogPostMetadata[]): GeneratedFile {
 	const output = new Feed({
 		title: `blog | ${SITE_NAME}`,
@@ -187,6 +210,14 @@ export function feed(posts: BlogPostMetadata[]): GeneratedFile {
 	return { path: 'feed.xml', content: output.rss2() };
 }
 
+/**
+ * Renders the generated core pages for the site.
+ *
+ * @param posts - Rendered local blog posts.
+ * @param externalPosts - Posts loaded from configured external feeds.
+ * @param assets - Bundled site assets referenced by the pages.
+ * @returns The generated core files.
+ */
 export function corePages(
 	posts: BlogPost[],
 	externalPosts: PostListItem[],

--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -6,6 +6,7 @@ import { formatDate } from '../lib/util.ts';
 import { islandModuleIds } from './assets.ts';
 import { SITE_COPYRIGHT, SITE_NAME, SITE_ORIGIN, SITE_SOCIAL_IMAGE_URL } from './consts.ts';
 import { postListItems } from './content.ts';
+import path from 'node:path';
 import { page, renderComponent } from './html.ts';
 import Article from './templates/Article.svelte';
 import BlogList from './templates/BlogList.svelte';
@@ -53,14 +54,19 @@ function articleImageUrl(html: string, articleUrl: string): string | undefined {
 			).href;
 }
 
+/**
+ * A file emitted by the static site generator.
+ */
 export type GeneratedFile = {
 	path: string;
 	content: string;
+	sourcePaths?: readonly string[];
 };
 
 export function homePage(assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'index.html',
+		sourcePaths: ['src/site/pages.ts', 'src/site/templates/Home.svelte'],
 		content: page({
 			title: '',
 			pathname: '/',
@@ -85,6 +91,12 @@ export function blogListPage(items: PostListItem[], assets: SiteAssets): Generat
 	const sorted = items.toSorted((a, b) => b.pubDate.localeCompare(a.pubDate));
 	return {
 		path: 'blog/index.html',
+		sourcePaths: [
+			'src/site/content.ts',
+			'src/site/templates/BlogList.svelte',
+			'packages/content/src/blog',
+			'src/contents/external-rss/rss.json',
+		],
 		content: page({
 			title: 'Blog',
 			pathname: '/blog/',
@@ -115,9 +127,12 @@ export function articlePages(post: BlogPost, assets: SiteAssets): GeneratedFile[
 		pathname,
 		post,
 	});
+	const sourcePath =
+		path.basename(post.filepath) === 'index.md' ? path.dirname(post.filepath) : post.filepath;
 	return [
 		{
 			path: `blog/${post.filename}/index.html`,
+			sourcePaths: [sourcePath],
 			content: page({
 				title: `${post.title} | blog`,
 				pathname,

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -15,6 +15,12 @@ type Publication = { title: string; link: string; authors: string; publisher: st
 export function ossPage(projects: Record<string, OssProject[]>, assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'works/oss/index.html',
+		sourcePaths: [
+			'src/site/sections.ts',
+			'src/site/secondary-pages.ts',
+			'src/site/templates/Oss.svelte',
+			'src/contents/works/oss/list.json',
+		],
 		content: page({
 			title: 'Open-source projects',
 			pathname: '/works/oss/',
@@ -30,6 +36,12 @@ export function ossPage(projects: Record<string, OssProject[]>, assets: SiteAsse
 export function showcasePage(projects: ShowcaseProject[], assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'works/showcase/index.html',
+		sourcePaths: [
+			'src/site/secondary-pages.ts',
+			'src/site/templates/Showcase.svelte',
+			'packages/content/src/showcase.ts',
+			'packages/content/src/showcase',
+		],
 		content: page({
 			title: 'Project showcase',
 			pathname: '/works/showcase/',
@@ -48,6 +60,12 @@ export function publicationsPage(
 ): GeneratedFile {
 	return {
 		path: 'works/publications/index.html',
+		sourcePaths: [
+			'src/site/sections.ts',
+			'src/site/secondary-pages.ts',
+			'src/site/templates/Publications.svelte',
+			'src/contents/publication.json',
+		],
 		content: page({
 			title: 'Publications',
 			pathname: '/works/publications/',
@@ -63,6 +81,11 @@ export function publicationsPage(
 export function talksPage(talks: Talk[], assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'works/talks/index.html',
+		sourcePaths: [
+			'src/site/sections.ts',
+			'src/site/secondary-pages.ts',
+			'src/site/templates/Talks.svelte',
+		],
 		content: page({
 			title: 'Talks',
 			pathname: '/works/talks/',
@@ -78,6 +101,7 @@ export function talksPage(talks: Talk[], assets: SiteAssets): GeneratedFile {
 export function sponsorsPage(assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'sponsors/index.html',
+		sourcePaths: ['src/site/secondary-pages.ts', 'src/site/templates/Sponsors.svelte'],
 		content: page({
 			title: 'Sponsors',
 			pathname: '/sponsors/',
@@ -93,6 +117,7 @@ export function sponsorsPage(assets: SiteAssets): GeneratedFile {
 export function errorPage(assets: SiteAssets): GeneratedFile {
 	return {
 		path: '404.html',
+		sourcePaths: ['src/site/secondary-pages.ts', 'src/site/templates/Error.svelte'],
 		content: page({
 			title: 'Page not found',
 			pathname: '/404',

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -12,6 +12,13 @@ import Talks from './templates/Talks.svelte';
 
 type Publication = { title: string; link: string; authors: string; publisher: string };
 
+/**
+ * Renders the open-source projects page.
+ *
+ * @param projects - Projects grouped by their genre.
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated open-source projects page.
+ */
 export function ossPage(projects: Record<string, OssProject[]>, assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'works/oss/index.html',
@@ -33,6 +40,13 @@ export function ossPage(projects: Record<string, OssProject[]>, assets: SiteAsse
 	};
 }
 
+/**
+ * Renders the project showcase page.
+ *
+ * @param projects - Showcase projects to render.
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated project showcase page.
+ */
 export function showcasePage(projects: ShowcaseProject[], assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'works/showcase/index.html',
@@ -54,6 +68,13 @@ export function showcasePage(projects: ShowcaseProject[], assets: SiteAssets): G
 	};
 }
 
+/**
+ * Renders the publications page.
+ *
+ * @param publications - Publications grouped by their year or category.
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated publications page.
+ */
 export function publicationsPage(
 	publications: Record<string, Publication[]>,
 	assets: SiteAssets,
@@ -78,6 +99,13 @@ export function publicationsPage(
 	};
 }
 
+/**
+ * Renders the talks page.
+ *
+ * @param talks - Talks loaded from the talks data source.
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated talks page.
+ */
 export function talksPage(talks: Talk[], assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'works/talks/index.html',
@@ -98,6 +126,12 @@ export function talksPage(talks: Talk[], assets: SiteAssets): GeneratedFile {
 	};
 }
 
+/**
+ * Renders the sponsors page.
+ *
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated sponsors page.
+ */
 export function sponsorsPage(assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'sponsors/index.html',
@@ -114,6 +148,12 @@ export function sponsorsPage(assets: SiteAssets): GeneratedFile {
 	};
 }
 
+/**
+ * Renders the non-indexable error page.
+ *
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated error page.
+ */
 export function errorPage(assets: SiteAssets): GeneratedFile {
 	return {
 		path: '404.html',

--- a/src/site/sitemap.ts
+++ b/src/site/sitemap.ts
@@ -1,5 +1,13 @@
 import type { GeneratedFile } from './pages.ts';
 
+/**
+ * A canonical URL and its optional source-derived modification timestamp.
+ */
+export type SitemapEntry = {
+	loc: string;
+	lastmod?: string;
+};
+
 function escapeXml(value: string): string {
 	return value
 		.replaceAll('&', '&amp;')
@@ -12,26 +20,34 @@ function escapeXml(value: string): string {
 /**
  * Builds the XML sitemap for the generated HTML routes.
  *
- * @param urls - Canonical URLs to include in the sitemap.
+ * @param entries - Canonical URLs and optional modification timestamps.
  * @returns The generated sitemap file.
  */
-export function sitemap(urls: readonly string[]): GeneratedFile {
+export function sitemap(entries: readonly SitemapEntry[]): GeneratedFile {
 	return {
 		path: 'sitemap.xml',
-		content: `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls.map((url) => `<url><loc>${escapeXml(url)}</loc></url>`).join('')}</urlset>`,
+		content: `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${entries
+			.map(
+				({ loc, lastmod }) =>
+					`<url><loc>${escapeXml(loc)}</loc>${lastmod == null ? '' : `<lastmod>${escapeXml(lastmod)}</lastmod>`}</url>`,
+			)
+			.join('')}</urlset>`,
 	};
 }
 
 if (import.meta.vitest != null) {
-	test('uses the sitemap protocol namespace without speculative modification dates', () => {
-		const result = sitemap(['https://ryoppippi.com/', 'https://example.com/search?q=seo&lang=en']);
+	test('serializes source-derived modification dates when supplied', () => {
+		const result = sitemap([
+			{ loc: 'https://ryoppippi.com/', lastmod: '2026-08-25T10:30:00.000Z' },
+			{ loc: 'https://example.com/search?q=seo&lang=en' },
+		]);
 
 		expect(result).toEqual({
 			path: 'sitemap.xml',
 			content:
-				'<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://ryoppippi.com/</loc></url><url><loc>https://example.com/search?q=seo&amp;lang=en</loc></url></urlset>',
+				'<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://ryoppippi.com/</loc><lastmod>2026-08-25T10:30:00.000Z</lastmod></url><url><loc>https://example.com/search?q=seo&amp;lang=en</loc></url></urlset>',
 		});
-		expect(result.content).not.toContain('<lastmod>');
+		expect(result.content).toContain('<lastmod>2026-08-25T10:30:00.000Z</lastmod>');
 		expect(result.content).toContain('&amp;lang=en');
 	});
 }


### PR DESCRIPTION
## Summary

- derive sitemap `<lastmod>` values from the latest Git commit touching each generated page's content source
- associate blog, showcase, OSS, publications, talks, sponsors, and home routes with their source paths
- omit `<lastmod>` when Git history is unavailable instead of publishing an unreliable deployment timestamp

## Testing

- `pnpm check`
- `pnpm test`
- `pnpm build`
- verified the generated `build/sitemap.xml` contains 75 source-derived `<lastmod>` entries, with article timestamps varying by Git history

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Git-backed <lastmod> to the sitemap and tracks shared page generator changes so page timestamps update when templates or shared code change. Previously entries had no lastmod; now each entry uses the latest commit touching its content or generator, and we omit lastmod when Git history is unavailable.

- New Features
- Introduces a `gitLastModified` helper that reads the latest commit timestamp for selected source paths, respecting `WORKERS_CI_COMMIT_SHA` and `CF_PAGES_COMMIT_SHA`.
- Attaches `sourcePaths` to generated pages (home, blog index and articles, showcase, publications, talks, sponsors, 404) to compute per-page timestamps.
- Updates sitemap generation to accept entries with optional lastmod and serialize it per URL.

- Bug Fixes
- Includes shared page generator files in `sourcePaths` for blog and article pages so generator or metadata changes advance their lastmod.

<sup>Written for commit 4f4addcef9395848c73fef1619c1233cd0edcce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sitemaps now include each page’s last-modified date when available.
  - Generated pages are linked to their source content, enabling more accurate update metadata across blog posts, home, showcase, publications, talks, sponsors, OSS, and error pages.
  - Sitemap entries safely include optional modification timestamps in the generated XML.

- **Bug Fixes**
  - Pages without available Git history continue to appear normally without a modification date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->