### PR TITLE
feat(seo): identify site owner in structured data

### DIFF
--- a/src/site/consts.ts
+++ b/src/site/consts.ts
@@ -10,6 +10,35 @@ export const SITE_ORIGIN = import.meta.env.PUBLIC_ORIGIN ?? DEFAULT_SITE_ORIGIN;
  */
 export const SITE_NAME = 'ryoppippi.com';
 
+type SiteOwnerIdentity = {
+	id: string;
+	name: string;
+	japaneseName: string;
+	formerName: string;
+	formerJapaneseName: string;
+	handle: string;
+	url: string;
+	sameAs: readonly string[];
+};
+
+export const SITE_OWNER = {
+	id: new URL('/#person', SITE_ORIGIN).href,
+	name: 'Ryotaro Kimura',
+	japaneseName: '木村亮太朗',
+	formerName: 'Ryotaro Miura',
+	formerJapaneseName: '三浦亮太朗',
+	handle: '@ryoppippi',
+	url: new URL('/', SITE_ORIGIN).href,
+	sameAs: [
+		'https://github.com/ryoppippi',
+		'https://www.linkedin.com/in/ryoppippi/',
+		'https://x.com/ryoppippi',
+		'https://bsky.app/profile/ryoppippi.com',
+		'https://www.youtube.com/channel/UCJbUM-yZx6mESJw82-OpMuQ',
+		'https://cv.ryoppippi.com/',
+	],
+} as const satisfies SiteOwnerIdentity;
+
 /**
  * JPEG URL used by social cards and feed metadata for broad consumer compatibility.
  */

--- a/src/site/consts.ts
+++ b/src/site/consts.ts
@@ -10,35 +10,6 @@ export const SITE_ORIGIN = import.meta.env.PUBLIC_ORIGIN ?? DEFAULT_SITE_ORIGIN;
  */
 export const SITE_NAME = 'ryoppippi.com';
 
-type SiteOwnerIdentity = {
-	id: string;
-	name: string;
-	japaneseName: string;
-	formerName: string;
-	formerJapaneseName: string;
-	handle: string;
-	url: string;
-	sameAs: readonly string[];
-};
-
-export const SITE_OWNER = {
-	id: new URL('/#person', SITE_ORIGIN).href,
-	name: 'Ryotaro Kimura',
-	japaneseName: '木村亮太朗',
-	formerName: 'Ryotaro Miura',
-	formerJapaneseName: '三浦亮太朗',
-	handle: '@ryoppippi',
-	url: new URL('/', SITE_ORIGIN).href,
-	sameAs: [
-		'https://github.com/ryoppippi',
-		'https://www.linkedin.com/in/ryoppippi/',
-		'https://x.com/ryoppippi',
-		'https://bsky.app/profile/ryoppippi.com',
-		'https://www.youtube.com/channel/UCJbUM-yZx6mESJw82-OpMuQ',
-		'https://cv.ryoppippi.com/',
-	],
-} as const satisfies SiteOwnerIdentity;
-
 /**
  * JPEG URL used by social cards and feed metadata for broad consumer compatibility.
  */

--- a/src/site/head.ts
+++ b/src/site/head.ts
@@ -1,9 +1,10 @@
-import type { Thing, WithContext } from 'schema-dts';
+import type { Graph, Thing, WithContext } from 'schema-dts';
 import { CanonicalPlugin, TemplateParamsPlugin, ValidatePlugin } from 'unhead/plugins';
 import { createHead } from 'unhead/server';
 import { SITE_NAME, SITE_ORIGIN, SITE_SOCIAL_IMAGE_URL } from './consts.ts';
 
 const pageHeadMarker = { 'data-page-head': '' } as const;
+type StructuredData = Graph | WithContext<Thing>;
 
 /**
  * Renders Unhead metadata into static HTML head tags.
@@ -29,7 +30,7 @@ export function renderPageHead({
 	indexable?: boolean;
 	lang: string;
 	pathname: string;
-	structuredData?: WithContext<Thing>;
+	structuredData?: StructuredData;
 	title: string;
 }): string {
 	const alternateLinks =

--- a/src/site/html.ts
+++ b/src/site/html.ts
@@ -1,10 +1,12 @@
 import type { Component } from 'svelte';
-import type { Thing, WithContext } from 'schema-dts';
+import type { Graph, Thing, WithContext } from 'schema-dts';
 import type { PageStyle, SiteAssets } from './assets.ts';
 import { render } from 'svelte/server';
 import { renderAssetTags } from './assets.ts';
 import { renderPageHead } from './head.ts';
 import Shell from './templates/Shell.svelte';
+
+type StructuredData = Graph | WithContext<Thing>;
 
 type PageOptions = {
 	article?: boolean;
@@ -20,7 +22,7 @@ type PageOptions = {
 	style: PageStyle;
 	title: string;
 	tweet?: boolean;
-	structuredData?: WithContext<Thing>;
+	structuredData?: StructuredData;
 };
 
 function normalizedLanguage(value: string | undefined): string {

--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -4,24 +4,19 @@ import type { PostListItem } from './content.ts';
 import { Feed } from 'feed';
 import { formatDate } from '../lib/util.ts';
 import { islandModuleIds } from './assets.ts';
-import {
-	SITE_COPYRIGHT,
-	SITE_NAME,
-	SITE_ORIGIN,
-	SITE_OWNER,
-	SITE_SOCIAL_IMAGE_URL,
-} from './consts.ts';
+import { SITE_COPYRIGHT, SITE_NAME, SITE_ORIGIN, SITE_SOCIAL_IMAGE_URL } from './consts.ts';
 import { postListItems } from './content.ts';
 import path from 'node:path';
 import { page, renderComponent } from './html.ts';
+import { SITE_OWNER } from './site-owner.ts';
 import Article from './templates/Article.svelte';
 import BlogList from './templates/BlogList.svelte';
 import Home from './templates/Home.svelte';
 
 type ArticleSeoMetadata = ArticleMetadata & { description: string };
 
-const HOME_DESCRIPTION =
-	'Portfolio and technical blog of Ryotaro Kimura (木村亮太朗), known as @ryoppippi, featuring open-source projects, talks, publications, and software engineering articles.';
+const SITE_OWNER_SOURCE_PATH = 'src/site/site-owner.ts';
+const HOME_DESCRIPTION = `Portfolio and technical blog of ${SITE_OWNER.name} (${SITE_OWNER.japaneseName}), known as ${SITE_OWNER.handle}, featuring open-source projects, talks, publications, and software engineering articles.`;
 
 function markdownDescription(content: string): string | undefined {
 	const paragraph = content
@@ -81,7 +76,7 @@ export type GeneratedFile = {
 export function homePage(assets: SiteAssets): GeneratedFile {
 	return {
 		path: 'index.html',
-		sourcePaths: ['src/site/templates/Home.svelte'],
+		sourcePaths: [SITE_OWNER_SOURCE_PATH, 'src/site/templates/Home.svelte'],
 		content: page({
 			title: '',
 			pathname: '/',
@@ -181,7 +176,7 @@ export function articlePages(post: BlogPost, assets: SiteAssets): GeneratedFile[
 	return [
 		{
 			path: `blog/${post.filename}/index.html`,
-			sourcePaths: [sourcePath],
+			sourcePaths: [SITE_OWNER_SOURCE_PATH, sourcePath],
 			content: page({
 				title: `${post.title} | blog`,
 				pathname,
@@ -299,7 +294,9 @@ if (import.meta.vitest != null) {
 	} satisfies BlogPost;
 
 	test('renders site identity metadata on the home page', () => {
-		const html = homePage(assets).content;
+		const home = homePage(assets);
+		expect(home.sourcePaths).toContain(SITE_OWNER_SOURCE_PATH);
+		const html = home.content;
 		expect(html).toContain(
 			`<meta data-page-head="" name="description" content="${HOME_DESCRIPTION}">`,
 		);
@@ -357,7 +354,7 @@ if (import.meta.vitest != null) {
 	test('renders article SEO metadata and reciprocal language links', () => {
 		const [article] = articlePages(examplePost, assets);
 		expect(article).toBeDefined();
-		expect(article?.sourcePaths).toEqual(['/content/example-article']);
+		expect(article?.sourcePaths).toEqual([SITE_OWNER_SOURCE_PATH, '/content/example-article']);
 		const html = article?.content ?? '';
 
 		expect(html).toContain('<html lang="en">');

--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -4,7 +4,13 @@ import type { PostListItem } from './content.ts';
 import { Feed } from 'feed';
 import { formatDate } from '../lib/util.ts';
 import { islandModuleIds } from './assets.ts';
-import { SITE_COPYRIGHT, SITE_NAME, SITE_ORIGIN, SITE_SOCIAL_IMAGE_URL } from './consts.ts';
+import {
+	SITE_COPYRIGHT,
+	SITE_NAME,
+	SITE_ORIGIN,
+	SITE_OWNER,
+	SITE_SOCIAL_IMAGE_URL,
+} from './consts.ts';
 import { postListItems } from './content.ts';
 import path from 'node:path';
 import { page, renderComponent } from './html.ts';
@@ -15,7 +21,7 @@ import Home from './templates/Home.svelte';
 type ArticleSeoMetadata = ArticleMetadata & { description: string };
 
 const HOME_DESCRIPTION =
-	'Portfolio and technical blog of @ryoppippi, featuring open-source projects, talks, publications, and software engineering articles.';
+	'Portfolio and technical blog of Ryotaro Kimura (木村亮太朗), known as @ryoppippi, featuring open-source projects, talks, publications, and software engineering articles.';
 
 function markdownDescription(content: string): string | undefined {
 	const paragraph = content
@@ -85,12 +91,39 @@ export function homePage(assets: SiteAssets): GeneratedFile {
 			style: 'home',
 			structuredData: {
 				'@context': 'https://schema.org',
-				'@type': 'WebSite',
-				'@id': `${SITE_ORIGIN}/#website`,
-				name: SITE_NAME,
-				alternateName: '@ryoppippi',
-				description: HOME_DESCRIPTION,
-				url: SITE_ORIGIN,
+				'@graph': [
+					{
+						'@type': 'WebSite',
+						'@id': `${SITE_ORIGIN}/#website`,
+						name: SITE_NAME,
+						alternateName: SITE_OWNER.handle,
+						description: HOME_DESCRIPTION,
+						url: SITE_OWNER.url,
+						creator: { '@id': SITE_OWNER.id },
+					},
+					{
+						'@type': 'ProfilePage',
+						'@id': `${SITE_ORIGIN}/#profile`,
+						url: SITE_OWNER.url,
+						isPartOf: { '@id': `${SITE_ORIGIN}/#website` },
+						mainEntity: { '@id': SITE_OWNER.id },
+					},
+					{
+						'@type': 'Person',
+						'@id': SITE_OWNER.id,
+						name: SITE_OWNER.name,
+						alternateName: [
+							SITE_OWNER.japaneseName,
+							SITE_OWNER.formerName,
+							SITE_OWNER.formerJapaneseName,
+							SITE_OWNER.handle,
+							'ryoppippi',
+						],
+						url: SITE_OWNER.url,
+						image: SITE_SOCIAL_IMAGE_URL,
+						sameAs: [...SITE_OWNER.sameAs],
+					},
+				],
 			},
 		}),
 	};
@@ -169,7 +202,13 @@ export function articlePages(post: BlogPost, assets: SiteAssets): GeneratedFile[
 					description: metadata.description,
 					url,
 					mainEntityOfPage: { '@type': 'WebPage', '@id': url },
-					author: { '@type': 'Person', name: 'ryoppippi', url: SITE_ORIGIN },
+					author: {
+						'@type': 'Person',
+						'@id': SITE_OWNER.id,
+						name: SITE_OWNER.name,
+						alternateName: [SITE_OWNER.japaneseName, SITE_OWNER.handle],
+						url: SITE_OWNER.url,
+					},
 					datePublished: post.pubDate,
 					...(image == null ? {} : { image }),
 					inLanguage: post.lang,
@@ -271,6 +310,50 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('"@type":"WebSite"');
 	});
 
+	test('keeps profile identity metadata out of the visible home page', () => {
+		const html = homePage(assets).content;
+		const body = html.match(/<body[^>]*>([\s\S]*)<\/body>/)?.[1];
+		assert.isDefined(body, 'expected a rendered document body');
+
+		expect(body).not.toContain('Ryotaro Kimura');
+		expect(body).not.toContain('木村亮太朗');
+		expect(body).not.toContain('Ryotaro Miura');
+		expect(body).not.toContain('三浦亮太朗');
+	});
+
+	test('identifies the home page owner with profile structured data', () => {
+		const html = homePage(assets).content;
+		const jsonLd = html.match(
+			/<script data-page-head="" type="application\/ld\+json">([\s\S]*?)<\/script>/,
+		)?.[1];
+		assert.isDefined(jsonLd, 'expected home page structured data');
+
+		expect(JSON.parse(jsonLd)).toMatchObject({
+			'@context': 'https://schema.org',
+			'@graph': expect.arrayContaining([
+				expect.objectContaining({
+					'@type': 'ProfilePage',
+					mainEntity: { '@id': 'https://ryoppippi.com/#person' },
+				}),
+				expect.objectContaining({
+					'@type': 'Person',
+					'@id': 'https://ryoppippi.com/#person',
+					name: 'Ryotaro Kimura',
+					alternateName: expect.arrayContaining([
+						'木村亮太朗',
+						'Ryotaro Miura',
+						'三浦亮太朗',
+						'@ryoppippi',
+					]),
+					sameAs: expect.arrayContaining([
+						'https://github.com/ryoppippi',
+						'https://cv.ryoppippi.com/',
+					]),
+				}),
+			]),
+		});
+	});
+
 	test('renders article SEO metadata and reciprocal language links', () => {
 		const [article] = articlePages(examplePost, assets);
 		expect(article).toBeDefined();
@@ -319,6 +402,13 @@ if (import.meta.vitest != null) {
 			datePublished: examplePost.pubDate,
 			image: 'https://ryoppippi.com/assets/content/article-cover.avif',
 			inLanguage: 'en',
+			author: {
+				'@type': 'Person',
+				'@id': 'https://ryoppippi.com/#person',
+				name: 'Ryotaro Kimura',
+				alternateName: expect.arrayContaining(['木村亮太朗', '@ryoppippi']),
+				url: 'https://ryoppippi.com/',
+			},
 		});
 	});
 

--- a/src/site/site-owner.ts
+++ b/src/site/site-owner.ts
@@ -1,0 +1,30 @@
+import { SITE_ORIGIN } from './consts.ts';
+
+type SiteOwnerIdentity = {
+	id: string;
+	name: string;
+	japaneseName: string;
+	formerName: string;
+	formerJapaneseName: string;
+	handle: string;
+	url: string;
+	sameAs: readonly string[];
+};
+
+export const SITE_OWNER = {
+	id: new URL('/#person', SITE_ORIGIN).href,
+	name: 'Ryotaro Kimura',
+	japaneseName: '木村亮太朗',
+	formerName: 'Ryotaro Miura',
+	formerJapaneseName: '三浦亮太朗',
+	handle: '@ryoppippi',
+	url: new URL('/', SITE_ORIGIN).href,
+	sameAs: [
+		'https://github.com/ryoppippi',
+		'https://www.linkedin.com/in/ryoppippi/',
+		'https://x.com/ryoppippi',
+		'https://bsky.app/profile/ryoppippi.com',
+		'https://www.youtube.com/channel/UCJbUM-yZx6mESJw82-OpMuQ',
+		'https://cv.ryoppippi.com/',
+	],
+} as const satisfies SiteOwnerIdentity;


### PR DESCRIPTION
Represent the homepage as a ProfilePage with one Person entity mapping Ryotaro Kimura / 木村亮太朗, former name Ryotaro Miura / 三浦亮太朗, and @ryoppippi to controlled profiles. Reuse the current identity in BlogPosting author metadata and allow the head renderer to accept typed JSON-LD graphs.

The Home and Article templates are unchanged, so the visible page rendering stays the same.

Validated with `pnpm check`, `pnpm test`, `pnpm build`, and `pnpm typos`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the site owner’s identity to JSON-LD and models the homepage as a ProfilePage so search engines can attribute the site correctly. Visible templates are unchanged, and sitemap lastmod now updates when owner metadata changes.

- New Features
  - Uses a JSON-LD graph with WebSite, ProfilePage, and a canonical Person linked by `@id`.
  - Articles reference the same Person for `BlogPosting.author`.
  - Centralizes identity in src/site/site-owner.ts to generate metadata and descriptions.
  - Head/HTML renderers accept graph-based structured data.

- Bug Fixes
  - Includes src/site/site-owner.ts in home and article source paths so sitemap dates reflect identity edits.

<sup>Written for commit 5113ecff46ae9d85c01b75cd3e67a38445237a91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer site identity information, including the site owner’s name, aliases, profile URL, and social links.
  * Expanded homepage metadata with website, profile, and person details.
  * Article metadata now includes consistent author information and profile references.
  * Structured data now supports broader schema formats, including graph-based metadata.

* **Tests**
  * Added coverage confirming profile details appear in structured metadata without being displayed in homepage content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->