### PR TITLE
fix(hooks): run staged checks in Nix dev shell

### DIFF
--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,1 +1,1 @@
-vp staged
+exec nix develop --command vp staged


### PR DESCRIPTION
Run the Vite+ staged hook through nix develop so Git clients such as Codex resolve the flake-provided gitleaks and other hook tools consistently with CI. Verified the generated pre-commit shim outside the dev shell, gitleaks detect, and vp check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs staged checks through `nix develop` so hooks resolve flake-provided tools like `gitleaks` consistently with CI. Previously the hook ran `vp staged` on the host shell, which failed when those tools weren’t on PATH; now it enters the Nix dev shell before running.

**Migration**
- Developers must have Nix installed; otherwise the pre-commit hook will fail.
- First run may be slower due to `nix develop` startup.

<sup>Written for commit a0c4a2b931ed44c42ad403093d8e6c40d31fe98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

