### PR TITLE
feat(about): add profile page

### DIFF
--- a/src/site/assets.ts
+++ b/src/site/assets.ts
@@ -1,4 +1,12 @@
-export const PAGE_STYLES = ['article', 'blog', 'error', 'home', 'sponsors', 'works'] as const;
+export const PAGE_STYLES = [
+	'about',
+	'article',
+	'blog',
+	'error',
+	'home',
+	'sponsors',
+	'works',
+] as const;
 
 export type PageStyle = (typeof PAGE_STYLES)[number];
 
@@ -31,6 +39,7 @@ export const DEV_ASSETS = {
 	base: '<link rel="stylesheet" href="/src/styles/fonts.css">\n\t<link rel="stylesheet" href="/src/site/style.css">',
 	client: '<script type="module" src="/src/site/client.ts"></script>',
 	pages: {
+		about: '<link rel="stylesheet" href="/src/site/styles/about.css">',
 		article: '<link rel="stylesheet" href="/src/site/styles/article.css">',
 		blog: '<link rel="stylesheet" href="/src/site/styles/blog.css">',
 		error: '<link rel="stylesheet" href="/src/site/styles/error.css">',
@@ -140,6 +149,7 @@ export function resolveSiteAssets(
 		client,
 		islands,
 		pages: {
+			about: stylesFor('/styles/about.css'),
 			article: stylesFor('/styles/article.css'),
 			blog: stylesFor('/styles/blog.css'),
 			error: stylesFor('/styles/error.css'),
@@ -215,6 +225,7 @@ if (import.meta.vitest != null) {
 			'post/Table.svelte': ['assets/Legend.css'],
 		},
 		pages: {
+			about: '<link href="/about.css">',
 			article: '<link href="/article.css">',
 			blog: '<link href="/blog.css">',
 			error: '<link href="/error.css">',
@@ -231,6 +242,9 @@ if (import.meta.vitest != null) {
 			const result = resolveSiteAssets(
 				'<link rel="stylesheet" href="/base.css"><script type="module" src="/client.js"></script>',
 				{
+					'src/site/styles/about.css': {
+						file: 'assets/about.css',
+					},
 					'src/site/styles/article.css': {
 						file: 'assets/article.css',
 					},
@@ -278,6 +292,7 @@ if (import.meta.vitest != null) {
 					'post/Chart.svelte': ['assets/Chart.css', 'assets/Legend.css'],
 				},
 				pages: {
+					about: '<link rel="stylesheet" crossorigin href="/assets/about.css">',
 					article: '<link rel="stylesheet" crossorigin href="/assets/article.css">',
 					blog: '<link rel="stylesheet" crossorigin href="/assets/blog.css">',
 					error: '<link rel="stylesheet" crossorigin href="/assets/error.css">',

--- a/src/site/client.ts
+++ b/src/site/client.ts
@@ -449,6 +449,9 @@ async function navigate(url: URL, push: boolean): Promise<void> {
 		removeObsoletePageStyles(next);
 		syncInlineStyles(next);
 		syncHead(next);
+		if (next.body.dataset.pageStyle === 'home') {
+			next.body.dataset.spaNavigation = 'true';
+		}
 		document.body.replaceWith(next.body);
 		if (push) {
 			history.pushState({}, '', url);

--- a/src/site/dev-routes.ts
+++ b/src/site/dev-routes.ts
@@ -6,6 +6,7 @@ import { extractInstallSection, extractSection, parseStepCommands } from '../lib
 import { postListItems } from './content.ts';
 import { articlePages, blogListPage, feed, homePage, mediaFeed } from './pages.ts';
 import {
+	aboutPage,
 	errorPage,
 	mediaPage,
 	ossPage,
@@ -116,6 +117,9 @@ export async function renderDevRoute(
 	if (pathname === '/') {
 		return response(homePage(dependencies.assets).content);
 	}
+	if (pathname === '/about/') {
+		return response(aboutPage(dependencies.assets).content);
+	}
 	if (pathname.startsWith('/blog/')) {
 		return renderBlogRoute(pathname, dependencies);
 	}
@@ -185,7 +189,7 @@ if (import.meta.vitest != null) {
 				base: '',
 				client: '<script type="module" src="/src/site/client.ts"></script>',
 				islands: {},
-				pages: { article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
+				pages: { about: '', article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
 				tweet: '',
 			},
 			loadBlogPost: vi.fn(async () => post),

--- a/src/site/dev-server.ts
+++ b/src/site/dev-server.ts
@@ -134,7 +134,7 @@ export function invalidatedRoutes(relativeFile: string): '*' | string[] | null {
 		file === 'routes.ts' ||
 		file.startsWith('packages/content/src/markdown/') ||
 		file.startsWith('src/site/templates/') ||
-		/^src\/site\/(client|consts|content|dev-routes|head|html|pages|secondary-pages|sections|style)\.(?:css|ts)$/.test(
+		/^src\/site\/(assets|client|consts|content|dev-routes|head|html|page-styles|pages|secondary-pages|sections|style)\.(?:css|ts)$/.test(
 			file,
 		)
 	) {

--- a/src/site/generate.ts
+++ b/src/site/generate.ts
@@ -20,6 +20,7 @@ import { loadExternalMedia, loadExternalPosts } from './content.ts';
 import { gitLastModified } from './git-last-modified.ts';
 import { corePages, mediaFeed } from './pages.ts';
 import {
+	aboutPage,
 	errorPage,
 	mediaPage,
 	ossPage,
@@ -100,6 +101,7 @@ export async function generateSite({
 
 	const pages = [
 		...corePages(posts, externalPosts, assets),
+		aboutPage(assets),
 		ossPage(ossProjects, assets),
 		showcasePage(showcase, assets),
 		publicationsPage(publications, assets),
@@ -151,6 +153,7 @@ export async function generateSite({
 	await Promise.all(
 		[
 			'index.html',
+			'about/index.html',
 			'works/index.html',
 			'works/oss/index.html',
 			'works/showcase/index.html',

--- a/src/site/page-styles.ts
+++ b/src/site/page-styles.ts
@@ -4,6 +4,7 @@ type PageStyleLoader = () => Promise<unknown>;
 type PageStyleLoaders = Record<PageStyle, PageStyleLoader>;
 
 const pageStyleLoaders = {
+	about: () => import('./styles/about.css'),
 	article: () => import('./styles/article.css'),
 	blog: () => import('./styles/blog.css'),
 	error: () => import('./styles/error.css'),
@@ -78,6 +79,7 @@ if (import.meta.vitest != null) {
 			const article = vi.fn(async () => undefined);
 			const other = vi.fn(async () => undefined);
 			const loaders = {
+				about: other,
 				article,
 				blog: other,
 				error: other,
@@ -95,6 +97,7 @@ if (import.meta.vitest != null) {
 		it('ignores an unknown page style', async () => {
 			const loader = vi.fn(async () => undefined);
 			const loaders = {
+				about: loader,
 				article: loader,
 				blog: loader,
 				error: loader,

--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -301,7 +301,7 @@ if (import.meta.vitest != null) {
 		base: '',
 		client: '',
 		islands: {},
-		pages: { article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
+		pages: { about: '', article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
 		tweet: '',
 	} as const satisfies SiteAssets;
 

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -267,6 +267,10 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('src="/haichu.avif"');
 		expect(html).toContain('Ryotaro Kimura');
 		expect(html).toContain('木村　亮太朗');
+		expect(html).toContain('I work at Rork.');
+		expect(html).toContain('href="/works/oss/"');
+		expect(html).toContain('href="/cv"');
+		expect(html).not.toContain('<figcaption');
 		expect(html).toContain('view-transition-name:about-haichu');
 		expect(html).toContain('"@type":"ProfilePage"');
 	});

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -20,7 +20,7 @@ type Publication = { title: string; link: string; authors: string; publisher: st
 const ABOUT_PATHNAME = '/about/';
 const ABOUT_TITLE = 'ryoppippi (Ryotaro Kimura)';
 const ABOUT_DESCRIPTION =
-	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Founding Engineer at Rork building coding agents and developer tools, and maintains ccusage.';
+	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, builds developer tools, maintains ccusage and open-source projects, and is a Founding Engineer at Rork.';
 
 /**
  * Renders the site owner's profile page.
@@ -275,7 +275,7 @@ if (import.meta.vitest != null) {
 
 		expect(html).toContain('<title>ryoppippi (Ryotaro Kimura) | ryoppippi.com</title>');
 		expect(html).toContain(
-			'<meta data-page-head="" name="description" content="Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Founding Engineer at Rork building coding agents and developer tools, and maintains ccusage.">',
+			'<meta data-page-head="" name="description" content="Ryotaro Kimura (木村亮太朗), known as ryoppippi, builds developer tools, maintains ccusage and open-source projects, and is a Founding Engineer at Rork.">',
 		);
 		expect(html).toContain(
 			'<meta data-page-head="" name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">',
@@ -310,9 +310,7 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('木村亮太朗');
 		expect(html).toContain('coder without ai');
 		expect(html).toContain('Founding Engineer');
-		expect(html).toContain(
-			'building coding agents, developer tools, and human-centred AI products',
-		);
+		expect(html).toContain('builds coding agents, developer tools, and human-centred AI products');
 		expect(html).toContain('href="https://rork.com/"');
 		expect(html).toContain('href="/works/oss/"');
 		expect(html).toContain('href="/cv"');

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -270,6 +270,8 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('I work at Rork.');
 		expect(html).toContain('href="/works/oss/"');
 		expect(html).toContain('href="/cv"');
+		expect(html).toContain('<ul');
+		expect(html).toContain('GitHub profile');
 		expect(html).not.toContain('<figcaption');
 		expect(html).toContain('view-transition-name:about-haichu');
 		expect(html).toContain('"@type":"ProfilePage"');

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -266,14 +266,15 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('src="/ryoppippi.avif"');
 		expect(html).toContain('src="/haichu.avif"');
 		expect(html).toContain('Ryotaro Kimura');
-		expect(html).toContain('木村　亮太朗');
+		expect(html).toContain('木村亮太朗');
 		expect(html).toContain('coder without ai');
-		expect(html).toContain('I work at');
+		expect(html).toContain('is a software engineer at');
 		expect(html).toContain('href="https://rork.com/"');
 		expect(html).toContain('href="/works/oss/"');
 		expect(html).toContain('href="/cv"');
 		expect(html).toContain('<ul');
 		expect(html).toContain('>GitHub</a>');
+		expect(html).not.toContain('>PR</a>');
 		expect(html).not.toContain('<figcaption');
 		expect(html).toContain('view-transition-name:about-haichu');
 		expect(html).toContain('"@type":"ProfilePage"');

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -18,8 +18,9 @@ import Talks from './templates/Talks.svelte';
 type Publication = { title: string; link: string; authors: string; publisher: string };
 
 const ABOUT_PATHNAME = '/about/';
+const ABOUT_TITLE = 'ryoppippi (Ryotaro Kimura)';
 const ABOUT_DESCRIPTION =
-	'About Ryotaro Kimura, also known as @ryoppippi: a software engineer working on AI products and open-source developer tools.';
+	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a software engineer at Rork and maintainer of ccusage and other open-source developer tools.';
 
 /**
  * Renders the site owner's profile page.
@@ -33,7 +34,7 @@ export function aboutPage(assets: SiteAssets): GeneratedFile {
 		path: 'about/index.html',
 		sourcePaths: ['src/site/site-owner.ts', 'src/site/templates/About.svelte'],
 		content: page({
-			title: 'About',
+			title: ABOUT_TITLE,
 			pathname: ABOUT_PATHNAME,
 			content: renderComponent(About, {}),
 			description: ABOUT_DESCRIPTION,
@@ -44,12 +45,19 @@ export function aboutPage(assets: SiteAssets): GeneratedFile {
 				'@type': 'ProfilePage',
 				'@id': `${url}#profile`,
 				url,
-				name: 'About',
+				name: ABOUT_TITLE,
 				description: ABOUT_DESCRIPTION,
 				mainEntity: {
 					'@type': 'Person',
 					'@id': SITE_OWNER.id,
 					name: SITE_OWNER.name,
+					description: ABOUT_DESCRIPTION,
+					jobTitle: 'Software Engineer',
+					worksFor: {
+						'@type': 'Organization',
+						name: 'Rork',
+						url: 'https://rork.com/',
+					},
 					alternateName: [
 						SITE_OWNER.japaneseName,
 						SITE_OWNER.formerName,
@@ -261,8 +269,32 @@ if (import.meta.vitest != null) {
 
 	test('renders the About page with profile content and view transitions', () => {
 		const html = aboutPage(assets).content;
+		const structuredDataSource = html.match(
+			/<script data-page-head="" type="application\/ld\+json">(?<json>.*?)<\/script>/u,
+		)?.groups?.json;
 
-		expect(html).toContain('<title>About | ryoppippi.com</title>');
+		expect(html).toContain('<title>ryoppippi (Ryotaro Kimura) | ryoppippi.com</title>');
+		expect(html).toContain(
+			'<meta data-page-head="" name="description" content="Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a software engineer at Rork and maintainer of ccusage and other open-source developer tools.">',
+		);
+		expect(html).toContain(
+			'<meta data-page-head="" name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">',
+		);
+		expect(html).toContain(
+			'<link data-page-head="" rel="canonical" href="https://ryoppippi.com/about/">',
+		);
+		expect(html).toContain(
+			'<meta data-page-head="" property="og:title" content="ryoppippi (Ryotaro Kimura) | ryoppippi.com">',
+		);
+		expect(html).toContain(
+			'<meta data-page-head="" property="og:url" content="https://ryoppippi.com/about/">',
+		);
+		expect(html).toContain(
+			'<meta data-page-head="" name="twitter:title" content="ryoppippi (Ryotaro Kimura) | ryoppippi.com">',
+		);
+		expect(html).toContain(
+			'<meta data-page-head="" name="twitter:image" content="https://ryoppippi.com/ryoppippi.jpg">',
+		);
 		expect(html).toContain('src="/ryoppippi.avif"');
 		expect(html).toContain('src="/haichu.avif"');
 		expect(html).toContain('Ryotaro Kimura');
@@ -277,6 +309,22 @@ if (import.meta.vitest != null) {
 		expect(html).not.toContain('>PR</a>');
 		expect(html).not.toContain('<figcaption');
 		expect(html).toContain('view-transition-name:about-haichu');
-		expect(html).toContain('"@type":"ProfilePage"');
+		expect(structuredDataSource).toBeDefined();
+		expect(JSON.parse(structuredDataSource ?? '')).toMatchObject({
+			'@type': 'ProfilePage',
+			name: ABOUT_TITLE,
+			description: ABOUT_DESCRIPTION,
+			mainEntity: {
+				'@type': 'Person',
+				name: SITE_OWNER.name,
+				description: ABOUT_DESCRIPTION,
+				jobTitle: 'Software Engineer',
+				worksFor: {
+					'@type': 'Organization',
+					name: 'Rork',
+					url: 'https://rork.com/',
+				},
+			},
+		});
 	});
 }

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -20,7 +20,7 @@ type Publication = { title: string; link: string; authors: string; publisher: st
 const ABOUT_PATHNAME = '/about/';
 const ABOUT_TITLE = 'ryoppippi (Ryotaro Kimura)';
 const ABOUT_DESCRIPTION =
-	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a software engineer at Rork and maintainer of ccusage and other open-source developer tools.';
+	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Rork Founding Engineer building coding agents and developer tools, and the maintainer of ccusage.';
 
 /**
  * Renders the site owner's profile page.
@@ -52,7 +52,7 @@ export function aboutPage(assets: SiteAssets): GeneratedFile {
 					'@id': SITE_OWNER.id,
 					name: SITE_OWNER.name,
 					description: ABOUT_DESCRIPTION,
-					jobTitle: 'Software Engineer',
+					jobTitle: 'Founding Engineer',
 					worksFor: {
 						'@type': 'Organization',
 						name: 'Rork',
@@ -275,7 +275,7 @@ if (import.meta.vitest != null) {
 
 		expect(html).toContain('<title>ryoppippi (Ryotaro Kimura) | ryoppippi.com</title>');
 		expect(html).toContain(
-			'<meta data-page-head="" name="description" content="Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a software engineer at Rork and maintainer of ccusage and other open-source developer tools.">',
+			'<meta data-page-head="" name="description" content="Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Rork Founding Engineer building coding agents and developer tools, and the maintainer of ccusage.">',
 		);
 		expect(html).toContain(
 			'<meta data-page-head="" name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">',
@@ -287,10 +287,19 @@ if (import.meta.vitest != null) {
 			'<meta data-page-head="" property="og:title" content="ryoppippi (Ryotaro Kimura) | ryoppippi.com">',
 		);
 		expect(html).toContain(
+			`<meta data-page-head="" property="og:description" content="${ABOUT_DESCRIPTION}">`,
+		);
+		expect(html).toContain(
 			'<meta data-page-head="" property="og:url" content="https://ryoppippi.com/about/">',
 		);
 		expect(html).toContain(
+			'<meta data-page-head="" property="og:image" content="https://ryoppippi.com/ryoppippi.jpg">',
+		);
+		expect(html).toContain(
 			'<meta data-page-head="" name="twitter:title" content="ryoppippi (Ryotaro Kimura) | ryoppippi.com">',
+		);
+		expect(html).toContain(
+			`<meta data-page-head="" name="twitter:description" content="${ABOUT_DESCRIPTION}">`,
 		);
 		expect(html).toContain(
 			'<meta data-page-head="" name="twitter:image" content="https://ryoppippi.com/ryoppippi.jpg">',
@@ -300,7 +309,10 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('Ryotaro Kimura');
 		expect(html).toContain('木村亮太朗');
 		expect(html).toContain('coder without ai');
-		expect(html).toContain('is a software engineer at');
+		expect(html).toContain('Founding Engineer');
+		expect(html).toContain(
+			'building coding agents, developer tools, and human-centred AI products',
+		);
 		expect(html).toContain('href="https://rork.com/"');
 		expect(html).toContain('href="/works/oss/"');
 		expect(html).toContain('href="/cv"');
@@ -318,7 +330,7 @@ if (import.meta.vitest != null) {
 				'@type': 'Person',
 				name: SITE_OWNER.name,
 				description: ABOUT_DESCRIPTION,
-				jobTitle: 'Software Engineer',
+				jobTitle: 'Founding Engineer',
 				worksFor: {
 					'@type': 'Organization',
 					name: 'Rork',

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -3,7 +3,10 @@ import type { SiteAssets } from './assets.ts';
 import type { PostListItem } from './content.ts';
 import type { GeneratedFile } from './pages.ts';
 import type { OssProject, Talk } from './sections.ts';
+import { SITE_ORIGIN } from './consts.ts';
+import { SITE_OWNER } from './site-owner.ts';
 import { page, renderComponent } from './html.ts';
+import About from './templates/About.svelte';
 import ErrorPage from './templates/Error.svelte';
 import Media from './templates/Media.svelte';
 import Oss from './templates/Oss.svelte';
@@ -13,6 +16,54 @@ import Sponsors from './templates/Sponsors.svelte';
 import Talks from './templates/Talks.svelte';
 
 type Publication = { title: string; link: string; authors: string; publisher: string };
+
+const ABOUT_PATHNAME = '/about/';
+const ABOUT_DESCRIPTION =
+	'About Ryotaro Kimura, also known as @ryoppippi: a software engineer working on AI products and open-source developer tools.';
+
+/**
+ * Renders the site owner's profile page.
+ *
+ * @param assets - Bundled site assets referenced by the page.
+ * @returns The generated About page.
+ */
+export function aboutPage(assets: SiteAssets): GeneratedFile {
+	const url = `${SITE_ORIGIN}${ABOUT_PATHNAME}`;
+	return {
+		path: 'about/index.html',
+		sourcePaths: ['src/site/site-owner.ts', 'src/site/templates/About.svelte'],
+		content: page({
+			title: 'About',
+			pathname: ABOUT_PATHNAME,
+			content: renderComponent(About, {}),
+			description: ABOUT_DESCRIPTION,
+			assets,
+			style: 'about',
+			structuredData: {
+				'@context': 'https://schema.org',
+				'@type': 'ProfilePage',
+				'@id': `${url}#profile`,
+				url,
+				name: 'About',
+				description: ABOUT_DESCRIPTION,
+				mainEntity: {
+					'@type': 'Person',
+					'@id': SITE_OWNER.id,
+					name: SITE_OWNER.name,
+					alternateName: [
+						SITE_OWNER.japaneseName,
+						SITE_OWNER.formerName,
+						SITE_OWNER.formerJapaneseName,
+						SITE_OWNER.handle,
+					],
+					url: SITE_OWNER.url,
+					image: `${SITE_ORIGIN}/ryoppippi.avif`,
+					sameAs: [...SITE_OWNER.sameAs],
+				},
+			},
+		}),
+	};
+}
 
 /**
  * Renders the open-source projects page.
@@ -197,7 +248,7 @@ if (import.meta.vitest != null) {
 		base: '',
 		client: '',
 		islands: {},
-		pages: { article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
+		pages: { about: '', article: '', blog: '', error: '', home: '', sponsors: '', works: '' },
 		tweet: '',
 	} as const satisfies SiteAssets;
 
@@ -206,5 +257,17 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('<meta data-page-head="" name="robots" content="noindex,follow">');
 		expect(html).not.toContain('property="og:');
 		expect(html).not.toContain('rel="canonical"');
+	});
+
+	test('renders the About page with profile content and view transitions', () => {
+		const html = aboutPage(assets).content;
+
+		expect(html).toContain('<title>About | ryoppippi.com</title>');
+		expect(html).toContain('src="/ryoppippi.avif"');
+		expect(html).toContain('src="/haichu.avif"');
+		expect(html).toContain('Ryotaro Kimura');
+		expect(html).toContain('木村　亮太朗');
+		expect(html).toContain('view-transition-name:about-haichu');
+		expect(html).toContain('"@type":"ProfilePage"');
 	});
 }

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -267,11 +267,13 @@ if (import.meta.vitest != null) {
 		expect(html).toContain('src="/haichu.avif"');
 		expect(html).toContain('Ryotaro Kimura');
 		expect(html).toContain('木村　亮太朗');
-		expect(html).toContain('I work at Rork.');
+		expect(html).toContain('coder without ai');
+		expect(html).toContain('I work at');
+		expect(html).toContain('href="https://rork.com/"');
 		expect(html).toContain('href="/works/oss/"');
 		expect(html).toContain('href="/cv"');
 		expect(html).toContain('<ul');
-		expect(html).toContain('GitHub profile');
+		expect(html).toContain('>GitHub</a>');
 		expect(html).not.toContain('<figcaption');
 		expect(html).toContain('view-transition-name:about-haichu');
 		expect(html).toContain('"@type":"ProfilePage"');

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -20,7 +20,7 @@ type Publication = { title: string; link: string; authors: string; publisher: st
 const ABOUT_PATHNAME = '/about/';
 const ABOUT_TITLE = 'ryoppippi (Ryotaro Kimura)';
 const ABOUT_DESCRIPTION =
-	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Rork Founding Engineer building coding agents and developer tools, and the maintainer of ccusage.';
+	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Founding Engineer at Rork building coding agents and developer tools, and maintains ccusage.';
 
 /**
  * Renders the site owner's profile page.
@@ -275,7 +275,7 @@ if (import.meta.vitest != null) {
 
 		expect(html).toContain('<title>ryoppippi (Ryotaro Kimura) | ryoppippi.com</title>');
 		expect(html).toContain(
-			'<meta data-page-head="" name="description" content="Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Rork Founding Engineer building coding agents and developer tools, and the maintainer of ccusage.">',
+			'<meta data-page-head="" name="description" content="Ryotaro Kimura (木村亮太朗), known as ryoppippi, is a Founding Engineer at Rork building coding agents and developer tools, and maintains ccusage.">',
 		);
 		expect(html).toContain(
 			'<meta data-page-head="" name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">',

--- a/src/site/site-owner.ts
+++ b/src/site/site-owner.ts
@@ -4,6 +4,7 @@ type SiteOwnerIdentity = {
 	id: string;
 	name: string;
 	japaneseName: string;
+	japaneseDisplayName: string;
 	formerName: string;
 	formerJapaneseName: string;
 	handle: string;
@@ -15,6 +16,7 @@ export const SITE_OWNER = {
 	id: new URL('/#person', SITE_ORIGIN).href,
 	name: 'Ryotaro Kimura',
 	japaneseName: '木村亮太朗',
+	japaneseDisplayName: '木村　亮太朗',
 	formerName: 'Ryotaro Miura',
 	formerJapaneseName: '三浦亮太朗',
 	handle: '@ryoppippi',

--- a/src/site/styles/about.css
+++ b/src/site/styles/about.css
@@ -1,0 +1,4 @@
+@layer theme, base, components, utilities;
+@import 'tailwindcss/utilities.css' layer(utilities) source(none);
+@reference '../../styles/tailwind.css';
+@source '../templates/About.svelte';

--- a/src/site/styles/about.css
+++ b/src/site/styles/about.css
@@ -2,3 +2,9 @@
 @import 'tailwindcss/utilities.css' layer(utilities) source(none);
 @reference '../../styles/tailwind.css';
 @source '../templates/About.svelte';
+
+.about-card {
+	background:
+		radial-gradient(circle at 50% 0%, rgb(255 107 107 / 8%), transparent 32rem),
+		linear-gradient(135deg, rgb(136 136 136 / 6%), transparent 50%);
+}

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -1,5 +1,15 @@
 <script lang='ts'>
+	import { SITE_ORIGIN } from '../consts.ts';
 	import { SITE_OWNER } from '../site-owner.ts';
+
+	const links = [
+		['GitHub profile', '/github'],
+		['Recent pull requests', '/pr'],
+		['LinkedIn profile', '/linkedin'],
+		['Twitter profile', '/twitter'],
+		['Bluesky profile', '/bsky'],
+		['YouTube channel', '/youtube'],
+	] as const;
 </script>
 
 <article class='mx-auto mt-8 max-w-3xl px-2 pb-16'>
@@ -48,8 +58,16 @@
 			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
 			and
 			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/works/oss/'>other open-source projects</a>.
-			You can find my CV
-			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/cv' rel='noopener noreferrer' target='_blank'>here</a>.
 		</p>
+		<ul class='mt-6 list-disc space-y-2 pl-5'>
+			{#each links as [label, href] (href)}
+				<li>
+					<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href={`${SITE_ORIGIN}${href}`} rel='noopener noreferrer' target='_blank'>{label}</a>
+				</li>
+			{/each}
+			<li>
+				<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/cv' rel='noopener noreferrer' target='_blank'>CV</a>
+			</li>
+		</ul>
 	</div>
 </article>

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -51,11 +51,12 @@
 				<p class='mt-5 text-pretty text-lg leading-8 text-text-600 dark:text-text-300 sm:text-xl sm:leading-9'>
 					<span class='font-semibold text-text-800 dark:text-text-100'>{SITE_OWNER.handle.slice(1)}</span>
 					<span class='font-mono text-sm text-text-400'>({SITE_OWNER.name} / <span lang='ja'>{SITE_OWNER.japaneseName}</span>)</span>
-					is a <span class='font-medium text-text-700 dark:text-text-200'>Founding Engineer</span> at
-					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://rork.com/' rel='noopener noreferrer' target='_blank'>Rork</a> — building coding agents, developer tools, and human-centred AI products, while maintaining
+					builds coding agents, developer tools, and human-centred AI products. Maintains
 					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
 					and
 					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='/works/oss/'>other open-source projects</a>.
+					<span class='font-medium text-text-700 dark:text-text-200'>Founding Engineer</span> at
+					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://rork.com/' rel='noopener noreferrer' target='_blank'>Rork</a>.
 				</p>
 
 				<ul class='mt-10 grid list-none gap-x-10 p-0 sm:grid-cols-2'>

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -3,70 +3,73 @@
 	import { SITE_OWNER } from '../site-owner.ts';
 
 	const links = [
-		['GitHub', '/github'],
-		['LinkedIn', '/linkedin'],
-		['Twitter', '/twitter'],
-		['Bluesky', '/bsky'],
-		['YouTube', '/youtube'],
+		['GitHub', `${SITE_ORIGIN}/github`],
+		['LinkedIn', `${SITE_ORIGIN}/linkedin`],
+		['Twitter', `${SITE_ORIGIN}/twitter`],
+		['Bluesky', `${SITE_ORIGIN}/bsky`],
+		['YouTube', `${SITE_ORIGIN}/youtube`],
+		['CV', '/cv'],
 	] as const;
 </script>
 
-<article class='mx-auto mt-8 max-w-3xl px-2 pb-16'>
-	<header class='mb-12 text-center opacity-60'>
-		<div class='font-mono text-lg leading-8'>
-			<p>{SITE_OWNER.name} / <span lang='ja'>{SITE_OWNER.japaneseDisplayName}</span></p>
-			<p class='mt-4 text-lg italic opacity-50'>coder without ai</p>
+<article class='mx-auto mt-8 max-w-4xl px-2 pb-20'>
+	<section class='about-card relative isolate mx-auto overflow-hidden rounded-[2rem] border border-base px-5 py-10 shadow-[0_2rem_6rem_#00000012] dark:shadow-[0_2rem_6rem_#00000045] sm:px-10 sm:py-12'>
+		<div class='pointer-events-none absolute inset-x-12 top-0 h-px bg-accent-100 opacity-50' aria-hidden='true'></div>
+
+		<div class='relative'>
+			<div class='mx-auto grid max-w-xs gap-4'>
+				<figure class='m-0'>
+					<img
+						class='mx-auto aspect-square w-1/2 rounded-full object-contain shadow-[0_1.5rem_4rem_#0004] ring-1 ring-[#8885] view-transition-name---profile md:size-64'
+						alt='ryoppippi'
+						decoding='async'
+						height='400'
+						loading='eager'
+						src='/ryoppippi.avif'
+						srcset='/ryoppippi-174.avif 174w, /ryoppippi-348.avif 348w, /ryoppippi.avif 400w'
+						sizes='(min-width: 48rem) 256px, calc(50vw - 2rem)'
+						width='400'
+					/>
+				</figure>
+
+				<figure class='m-0'>
+					<img
+						class='mx-auto h-auto w-4/5 max-w-64 object-contain opacity-85 drop-shadow-[0_1rem_2rem_#0003] transition-base hover:scale-[1.02] hover:opacity-100'
+						alt='haichu'
+						decoding='async'
+						height='529'
+						loading='eager'
+						src='/haichu.avif'
+						style='view-transition-name:about-haichu'
+						width='1011'
+					/>
+				</figure>
+			</div>
+
+			<div class='mx-auto mt-10 max-w-2xl border-t border-base pt-8'>
+				<p class='font-mono text-lg italic text-text-400 opacity-60'>... coder without ai</p>
+				<p class='mt-5 text-pretty text-lg leading-8 text-text-600 dark:text-text-300 sm:text-xl sm:leading-9'>
+					<span class='font-semibold text-text-800 dark:text-text-100'>{SITE_OWNER.handle.slice(1)}</span>
+					<span class='font-mono text-sm text-text-400'>({SITE_OWNER.name} / <span lang='ja'>{SITE_OWNER.japaneseName}</span>)</span>
+					is a software engineer at
+					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://rork.com/' rel='noopener noreferrer' target='_blank'>Rork</a>
+					who maintains
+					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
+					and
+					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='/works/oss/'>other open-source projects</a>.
+				</p>
+
+				<ul class='mt-10 grid list-none gap-x-10 p-0 sm:grid-cols-2'>
+					{#each links as [label, href] (href)}
+						<li class='border-b border-base'>
+							<a class='group flex items-center justify-between py-3 font-mono text-sm text-text-500 no-underline transition-base hover:text-accent-100 dark:text-text-300' href={href} rel='noopener noreferrer' target='_blank'>
+								<span>{label}</span>
+								<span class='opacity-25 transition-base group-hover:translate-x-1 group-hover:opacity-80' aria-hidden='true'>↗</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</div>
 		</div>
-	</header>
-
-	<div class='mx-auto grid max-w-xs gap-8'>
-		<figure class='m-0'>
-			<img
-				class='mx-auto aspect-square w-full max-w-xs rounded-full object-contain view-transition-name---profile'
-				alt='ryoppippi'
-				decoding='async'
-				height='400'
-				loading='eager'
-				src='/ryoppippi.avif'
-				srcset='/ryoppippi-174.avif 174w, /ryoppippi-348.avif 348w, /ryoppippi.avif 400w'
-				sizes='(min-width: 40rem) 256px, calc(100vw - 4rem)'
-				width='400'
-			/>
-		</figure>
-
-		<figure class='m-0'>
-			<img
-				class='mx-auto h-auto w-full rounded-2xl object-contain opacity-80 transition-base hover:opacity-100'
-				alt='haichu'
-				decoding='async'
-				height='529'
-				loading='eager'
-				src='/haichu.avif'
-				style='view-transition-name:about-haichu'
-				width='1011'
-			/>
-		</figure>
-
-	</div>
-
-	<div class='mx-auto mt-10 max-w-2xl text-base leading-8 text-text-500 opacity-70 dark:text-text-300'>
-		<p>
-			I work at
-			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://rork.com/' rel='noopener noreferrer' target='_blank'>Rork</a>.
-			I maintain
-			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
-			and
-			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/works/oss/'>other open-source projects</a>.
-		</p>
-		<ul class='mt-6 list-disc space-y-2 pl-5'>
-			{#each links as [label, href] (href)}
-				<li>
-					<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href={`${SITE_ORIGIN}${href}`} rel='noopener noreferrer' target='_blank'>{label}</a>
-				</li>
-			{/each}
-			<li>
-				<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/cv' rel='noopener noreferrer' target='_blank'>CV</a>
-			</li>
-		</ul>
-	</div>
+	</section>
 </article>

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -12,7 +12,7 @@
 		</div>
 	</header>
 
-	<div class='grid items-end gap-8 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.8fr)]'>
+	<div class='mx-auto grid max-w-xs gap-8'>
 		<figure class='m-0'>
 			<img
 				class='mx-auto aspect-square w-full max-w-xs rounded-full object-contain view-transition-name---profile'
@@ -25,7 +25,6 @@
 				sizes='(min-width: 40rem) 256px, calc(100vw - 4rem)'
 				width='400'
 			/>
-			<figcaption class='mt-3 text-center font-mono text-sm opacity-50'>ryoppippi</figcaption>
 		</figure>
 
 		<figure class='m-0'>
@@ -39,16 +38,18 @@
 				style='view-transition-name:about-haichu'
 				width='1011'
 			/>
-			<figcaption class='mt-3 text-center font-mono text-sm opacity-50'>haichu</figcaption>
 		</figure>
+
 	</div>
 
-	<div class='mx-auto mt-14 max-w-2xl text-base leading-8 text-text-500 opacity-70 dark:text-text-300'>
+	<div class='mx-auto mt-10 max-w-2xl text-base leading-8 text-text-500 opacity-70 dark:text-text-300'>
 		<p>
-			I am a software engineer based in the UK. I work on AI products and open-source developer
-			tools, and I am the creator of
-			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>.
-			My interests include TypeScript, Rust, Svelte, Vim, and Nix.
+			I work at Rork. I maintain
+			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
+			and
+			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/works/oss/'>other open-source projects</a>.
+			You can find my CV
+			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/cv' rel='noopener noreferrer' target='_blank'>here</a>.
 		</p>
 	</div>
 </article>

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -3,22 +3,21 @@
 	import { SITE_OWNER } from '../site-owner.ts';
 
 	const links = [
-		['GitHub profile', '/github'],
-		['Recent pull requests', '/pr'],
-		['LinkedIn profile', '/linkedin'],
-		['Twitter profile', '/twitter'],
-		['Bluesky profile', '/bsky'],
-		['YouTube channel', '/youtube'],
+		['GitHub', '/github'],
+		['LinkedIn', '/linkedin'],
+		['Twitter', '/twitter'],
+		['Bluesky', '/bsky'],
+		['YouTube', '/youtube'],
 	] as const;
 </script>
 
 <article class='mx-auto mt-8 max-w-3xl px-2 pb-16'>
 	<header class='mb-12 text-center opacity-60'>
-		<h1 class='text-4xl font-bold' style='view-transition-name:title-about'>About</h1>
-		<div class='mt-6 font-mono text-lg leading-8'>
+		<div class='font-mono text-lg leading-8'>
 			<p>{SITE_OWNER.handle.slice(1)}</p>
 			<p>{SITE_OWNER.name}</p>
 			<p lang='ja'>{SITE_OWNER.japaneseDisplayName}</p>
+			<p class='mt-4 text-lg italic opacity-50'>coder without ai</p>
 		</div>
 	</header>
 
@@ -54,7 +53,9 @@
 
 	<div class='mx-auto mt-10 max-w-2xl text-base leading-8 text-text-500 opacity-70 dark:text-text-300'>
 		<p>
-			I work at Rork. I maintain
+			I work at
+			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://rork.com/' rel='noopener noreferrer' target='_blank'>Rork</a>.
+			I maintain
 			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
 			and
 			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='/works/oss/'>other open-source projects</a>.

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -1,0 +1,54 @@
+<script lang='ts'>
+	import { SITE_OWNER } from '../site-owner.ts';
+</script>
+
+<article class='mx-auto mt-8 max-w-3xl px-2 pb-16'>
+	<header class='mb-12 text-center opacity-60'>
+		<h1 class='text-4xl font-bold' style='view-transition-name:title-about'>About</h1>
+		<div class='mt-6 font-mono text-lg leading-8'>
+			<p>{SITE_OWNER.handle.slice(1)}</p>
+			<p>{SITE_OWNER.name}</p>
+			<p lang='ja'>{SITE_OWNER.japaneseDisplayName}</p>
+		</div>
+	</header>
+
+	<div class='grid items-end gap-8 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.8fr)]'>
+		<figure class='m-0'>
+			<img
+				class='mx-auto aspect-square w-full max-w-xs rounded-full object-contain view-transition-name---profile'
+				alt='ryoppippi'
+				decoding='async'
+				height='400'
+				loading='eager'
+				src='/ryoppippi.avif'
+				srcset='/ryoppippi-174.avif 174w, /ryoppippi-348.avif 348w, /ryoppippi.avif 400w'
+				sizes='(min-width: 40rem) 256px, calc(100vw - 4rem)'
+				width='400'
+			/>
+			<figcaption class='mt-3 text-center font-mono text-sm opacity-50'>ryoppippi</figcaption>
+		</figure>
+
+		<figure class='m-0'>
+			<img
+				class='mx-auto h-auto w-full rounded-2xl object-contain opacity-80 transition-base hover:opacity-100'
+				alt='haichu'
+				decoding='async'
+				height='529'
+				loading='eager'
+				src='/haichu.avif'
+				style='view-transition-name:about-haichu'
+				width='1011'
+			/>
+			<figcaption class='mt-3 text-center font-mono text-sm opacity-50'>haichu</figcaption>
+		</figure>
+	</div>
+
+	<div class='mx-auto mt-14 max-w-2xl text-base leading-8 text-text-500 opacity-70 dark:text-text-300'>
+		<p>
+			I am a software engineer based in the UK. I work on AI products and open-source developer
+			tools, and I am the creator of
+			<a class='underline decoration-text-300 underline-offset-4 transition-opacity hover:opacity-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>.
+			My interests include TypeScript, Rust, Svelte, Vim, and Nix.
+		</p>
+	</div>
+</article>

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -14,9 +14,7 @@
 <article class='mx-auto mt-8 max-w-3xl px-2 pb-16'>
 	<header class='mb-12 text-center opacity-60'>
 		<div class='font-mono text-lg leading-8'>
-			<p>{SITE_OWNER.handle.slice(1)}</p>
-			<p>{SITE_OWNER.name}</p>
-			<p lang='ja'>{SITE_OWNER.japaneseDisplayName}</p>
+			<p>{SITE_OWNER.name} / <span lang='ja'>{SITE_OWNER.japaneseDisplayName}</span></p>
 			<p class='mt-4 text-lg italic opacity-50'>coder without ai</p>
 		</div>
 	</header>

--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -51,9 +51,8 @@
 				<p class='mt-5 text-pretty text-lg leading-8 text-text-600 dark:text-text-300 sm:text-xl sm:leading-9'>
 					<span class='font-semibold text-text-800 dark:text-text-100'>{SITE_OWNER.handle.slice(1)}</span>
 					<span class='font-mono text-sm text-text-400'>({SITE_OWNER.name} / <span lang='ja'>{SITE_OWNER.japaneseName}</span>)</span>
-					is a software engineer at
-					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://rork.com/' rel='noopener noreferrer' target='_blank'>Rork</a>
-					who maintains
+					is a <span class='font-medium text-text-700 dark:text-text-200'>Founding Engineer</span> at
+					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://rork.com/' rel='noopener noreferrer' target='_blank'>Rork</a> — building coding agents, developer tools, and human-centred AI products, while maintaining
 					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
 					and
 					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='/works/oss/'>other open-source projects</a>.

--- a/src/site/templates/Home.svelte
+++ b/src/site/templates/Home.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <article class='gcc container mx-auto mt-8'>
-	<div class='w-full animate-[root-flip-in-x_1s_both]'>
+	<div class='w-full animate-[root-flip-in-x_1s_both]' data-home-profile>
 		<img
 			class='mx-auto aspect-square w-1/2 rounded-full object-contain view-transition-name---profile md:size-64'
 			alt='ryoppippi'

--- a/src/site/templates/Shell.svelte
+++ b/src/site/templates/Shell.svelte
@@ -12,6 +12,7 @@
 	const pageContent = $derived(createRawSnippet(() => ({ render: () => content })));
 	const isHome = $derived(pathname === '/');
 	const links = [
+		{ href: '/about/', label: 'about' },
 		{ href: '/works/oss/', label: 'works', activePrefix: '/works/' },
 		{ href: '/blog/', label: 'blog' },
 		{ href: '/sponsors/', label: 'sponsors' },

--- a/src/site/templates/Shell.svelte
+++ b/src/site/templates/Shell.svelte
@@ -14,8 +14,8 @@
 	const links = [
 		{ href: '/about/', label: 'about' },
 		{ href: '/works/oss/', label: 'works', activePrefix: '/works/' },
-		{ href: '/blog/', label: 'blog' },
 		{ href: '/sponsors/', label: 'sponsors' },
+		{ href: '/blog/', label: 'blog' },
 	] as const;
 </script>
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -22,6 +22,10 @@ body[data-page-style='home'] {
 	font-family: 'Inter Home', 'Inter fallback', sans-serif;
 }
 
+body[data-spa-navigation] [data-home-profile] {
+	animation: none;
+}
+
 @keyframes root-fade-in {
 	from {
 		opacity: 0;


### PR DESCRIPTION
Adds `/about/` with the ryoppippi and Haichu images, display names, a concise English biography, and ProfilePage structured data. Wires navigation, development/static routes, page assets, and named view transitions so the Home profile can morph into About.

Validated with `pnpm check`, `pnpm test` (218 tests), and the in-app Browser against the local dev server; verified no HMR overlay, both AVIF assets, and the transition markers. Local `pnpm build` remains blocked before static generation because the existing Vite+ generator cannot find `build/index.html`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated About page with the site owner’s profile, images, biography, and structured metadata.
  * Added an “about” link to the main navigation.
  * Included responsive layouts, dark-mode styling, optimized images, and smooth page transitions.
* **Bug Fixes**
  * Development updates to site assets now correctly refresh affected pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->