### PR TITLE
fix(oss): derive ccusage language from GitHub metadata

### DIFF
--- a/.github/update-oss-stars.nu
+++ b/.github/update-oss-stars.nu
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix
 #! nix shell --inputs-from . nixpkgs#nushell nixpkgs#gh --command nu
 
-# Refresh the GitHub star snapshot consumed by the static OSS page.
+# Refresh the GitHub repository metadata snapshot consumed by the static OSS page.
 
 const list_path = 'src/contents/works/oss/list.json'
 const stars_path = 'src/contents/works/oss/stars.json'
@@ -25,17 +25,19 @@ def github-repository [project: record]: nothing -> string {
     $"($matches.0.owner)/($repository)"
 }
 
-def fetch-star-count [repository: string]: nothing -> int {
-    ^gh api $"repos/($repository)" --jq '.stargazers_count'
-    | str trim
-    | into int
-}
-
-def fetch-project [project: record]: nothing -> record<repo: string, stars: int> {
+def fetch-project [project: record]: nothing -> record {
     let repo = github-repository $project
-    let stars = fetch-star-count $repo
-    print $"($repo): ($stars) stars"
-    {repo: $repo, stars: $stars}
+    let metadata = (
+        ^gh api $"repos/($repo)"
+        --jq '{stars: .stargazers_count, primaryLanguage: .language}'
+        | from json
+    )
+    print $"($repo): ($metadata.stars) stars, ($metadata.primaryLanguage | default 'unknown')"
+    {
+        repo: $repo
+        stars: $metadata.stars
+        primaryLanguage: $metadata.primaryLanguage
+    }
 }
 
 def snapshot-timestamp []: nothing -> string {

--- a/.github/workflows/update-oss-stars.yaml
+++ b/.github/workflows/update-oss-stars.yaml
@@ -1,4 +1,4 @@
-name: Update OSS Star Counts
+name: Update OSS Repository Metadata
 
 on:
   workflow_dispatch:
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 jobs:
-  update-stars:
+  update-metadata:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
-      - name: Update star snapshot
+      - name: Update repository metadata snapshot
         run: ./.github/update-oss-stars.nu
         env:
           GH_TOKEN: ${{ github.token }}
@@ -46,5 +46,5 @@ jobs:
           git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git config --local user.name 'github-actions[bot]'
           git add src/contents/works/oss/stars.json
-          git commit -m 'chore(oss): update GitHub star counts'
+          git commit -m 'chore(oss): update GitHub repository metadata'
           git push

--- a/src/contents/works/oss/README.md
+++ b/src/contents/works/oss/README.md
@@ -38,12 +38,14 @@ few stars.
 Removing a project from this list does not remove its repository, package, or
 blog post. This file only controls the curated OSS index.
 
-## Star counts
+## Repository metadata
 
 `stars.json` is generated from GitHub repository metadata for my repositories
-(`ryoppippi/*`) by `.github/update-oss-stars.nu`. The scheduled workflow
-refreshes it daily and commits only when a count changes; edit `list.json` for
-project selection and descriptions instead of editing the snapshot by hand.
+(`ryoppippi/*`) by `.github/update-oss-stars.nu`. It contains star counts and
+primary languages; the scheduled workflow refreshes it daily and commits only
+when metadata changes. Edit `list.json` for project selection and descriptions
+instead of editing the snapshot by hand. Set `useGitHubPrimaryLanguage` on an
+entry when its language tag should come from the snapshot.
 
 ## OSS and Showcase
 

--- a/src/contents/works/oss/list.json
+++ b/src/contents/works/oss/list.json
@@ -3,7 +3,8 @@
 		"name": "ccusage",
 		"link": "https://github.com/ryoppippi/ccusage",
 		"icon": "icon-[ph--chart-line-light]",
-		"tags": ["AI", "CLI", "TypeScript"],
+		"tags": ["AI", "CLI"],
+		"useGitHubPrimaryLanguage": true,
 		"description": "Analyze coding-agent token usage and costs from local data."
 	},
 	{

--- a/src/contents/works/oss/stars.json
+++ b/src/contents/works/oss/stars.json
@@ -1,101 +1,125 @@
 {
-  "updatedAt": "2026-08-25T12:13:27Z",
+  "updatedAt": "2026-08-25T15:51:22Z",
   "projects": [
     {
       "repo": "ryoppippi/bad-apple",
-      "stars": 24
+      "stars": 24,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/ccusage",
-      "stars": 18155
+      "stars": 18156,
+      "primaryLanguage": "Rust"
     },
     {
       "repo": "ryoppippi/curxy",
-      "stars": 417
+      "stars": 417,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/dotfiles",
-      "stars": 259
+      "stars": 259,
+      "primaryLanguage": "Nix"
     },
     {
       "repo": "ryoppippi/fish-na",
-      "stars": 7
+      "stars": 7,
+      "primaryLanguage": "Shell"
     },
     {
       "repo": "ryoppippi/gh-nippou",
-      "stars": 14
+      "stars": 14,
+      "primaryLanguage": "Go"
     },
     {
       "repo": "ryoppippi/gray-matter-es",
-      "stars": 4
+      "stars": 4,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/limo",
-      "stars": 7
+      "stars": 7,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/nix-secure-enclave-key",
-      "stars": 10
+      "stars": 10,
+      "primaryLanguage": "Nushell"
     },
     {
       "repo": "ryoppippi/nvim-in-the-loop",
-      "stars": 28
+      "stars": 28,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/nvim-pnpm-catalog-lens",
-      "stars": 11
+      "stars": 11,
+      "primaryLanguage": "Lua"
     },
     {
       "repo": "ryoppippi/nvim-reset",
-      "stars": 13
+      "stars": 13,
+      "primaryLanguage": "Lua"
     },
     {
       "repo": "ryoppippi/nyancat.zig",
-      "stars": 23
+      "stars": 23,
+      "primaryLanguage": "Zig"
     },
     {
       "repo": "ryoppippi/sitemcp",
-      "stars": 758
+      "stars": 758,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/str-fns",
-      "stars": 3
+      "stars": 3,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/svelte-fancy-darkmode",
-      "stars": 9
+      "stars": 9,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/svelte-preprocess-budoux",
-      "stars": 7
+      "stars": 7,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/svelte-preprocess-import-css",
-      "stars": 4
+      "stars": 4,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/sveltweet",
-      "stars": 8
+      "stars": 8,
+      "primaryLanguage": "Svelte"
     },
     {
       "repo": "ryoppippi/tgrab",
-      "stars": 11
+      "stars": 11,
+      "primaryLanguage": "Rust"
     },
     {
       "repo": "ryoppippi/vim-svelte-inspector",
-      "stars": 22
+      "stars": 22,
+      "primaryLanguage": "Lua"
     },
     {
       "repo": "ryoppippi/vite-plugin-favicons",
-      "stars": 3
+      "stars": 3,
+      "primaryLanguage": "HTML"
     },
     {
       "repo": "ryoppippi/web-push-neo",
-      "stars": 11
+      "stars": 11,
+      "primaryLanguage": "TypeScript"
     },
     {
       "repo": "ryoppippi/zigcv",
-      "stars": 162
+      "stars": 162,
+      "primaryLanguage": "Zig"
     }
   ]
 }

--- a/src/site/sections.ts
+++ b/src/site/sections.ts
@@ -25,11 +25,13 @@ export type OssProject = {
 };
 
 type OssProjectSource = Omit<OssProject, 'link' | 'slug' | 'description' | 'kind' | 'stars'> &
-	Partial<Pick<OssProject, 'link' | 'slug' | 'description' | 'kind'>>;
+	Partial<Pick<OssProject, 'link' | 'slug' | 'description' | 'kind'>> & {
+		useGitHubPrimaryLanguage?: boolean;
+	};
 
 type OssStarSnapshot = {
 	updatedAt: string;
-	projects: Array<{ repo: string; stars: number }>;
+	projects: Array<{ repo: string; stars: number; primaryLanguage?: string | null }>;
 };
 
 function githubRepository(link: string): string | null {
@@ -55,10 +57,22 @@ export async function loadOssProjects(root: string): Promise<OssProject[]> {
 	const projects = JSON.parse(source) as OssProjectSource[];
 	const stars = JSON.parse(starSnapshot) as OssStarSnapshot;
 	const starCounts = new Map(stars.projects.map(({ repo, stars: count }) => [repo, count]));
+	const primaryLanguages = new Map(
+		stars.projects.map(({ repo, primaryLanguage }) => [repo, primaryLanguage ?? null]),
+	);
 	return Promise.all(
 		projects.map(async (project) => {
+			const { useGitHubPrimaryLanguage = false, ...projectData } = project;
 			const link = project.link ?? `https://github.com/ryoppippi/${project.name}`;
 			const repository = githubRepository(link);
+			const primaryLanguage =
+				repository == null ? null : (primaryLanguages.get(repository) ?? null);
+			const tags =
+				useGitHubPrimaryLanguage &&
+				primaryLanguage != null &&
+				!project.tags.includes(primaryLanguage)
+					? [...project.tags, primaryLanguage]
+					: project.tags;
 			let description = project.description ?? null;
 			if (description == null) {
 				try {
@@ -74,11 +88,12 @@ export async function loadOssProjects(root: string): Promise<OssProject[]> {
 				}
 			}
 			return {
-				...project,
+				...projectData,
 				link,
 				slug: project.slug ?? `ryoppippi-${project.name}`,
 				description,
 				kind: project.kind ?? 'project',
+				tags,
 				stars: repository == null ? null : (starCounts.get(repository) ?? null),
 			} satisfies OssProject;
 		}),
@@ -101,4 +116,30 @@ export async function loadPublications(
 	return JSON.parse(
 		await readFile(path.join(root, 'src/contents/publication.json'), 'utf8'),
 	) as Record<string, Array<{ title: string; link: string; authors: string; publisher: string }>>;
+}
+
+if (import.meta.vitest != null) {
+	test('uses the GitHub primary language for opted-in OSS projects', async () => {
+		const { createFixture } = await import('fs-fixture');
+		await using fixture = await createFixture({
+			'src/contents/works/oss/list.json': JSON.stringify([
+				{
+					name: 'ccusage',
+					link: 'https://github.com/ccusage/ccusage',
+					icon: 'icon',
+					tags: ['AI', 'CLI'],
+					useGitHubPrimaryLanguage: true,
+					description: 'Token usage analyser',
+				},
+			]),
+			'src/contents/works/oss/stars.json': JSON.stringify({
+				updatedAt: '2026-08-25T00:00:00Z',
+				projects: [{ repo: 'ccusage/ccusage', stars: 1, primaryLanguage: 'Rust' }],
+			}),
+		});
+
+		expect(await loadOssProjects(fixture.getPath('.'))).toMatchObject([
+			{ tags: ['AI', 'CLI', 'Rust'], stars: 1 },
+		]);
+	});
 }


### PR DESCRIPTION
Update the ccusage portfolio entry to use GitHub repository metadata for its primary-language tag, so the current Rust implementation is shown instead of stale TypeScript metadata.

What changed:
- extend the existing repository metadata snapshot with GitHub primary languages
- opt ccusage into the snapshot-backed language tag
- update the scheduled workflow, documentation, and generated snapshot

Validation:
- pnpm check
- pnpm test
- pnpm build
