### PR TITLE
perf(ci): use a minimal Nix shell for checks

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -7,6 +7,8 @@ runs:
       uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
       with:
         github_access_token: ${{ github.token }}
+        nix_conf: |
+          max-jobs = auto
 
     - name: Load CI tools and install JavaScript dependencies
       shell: bash

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,5 +1,5 @@
 name: Setup Nix
-description: Install Nix and load the development environment
+description: Install Nix and load the CI development environment
 runs:
   using: composite
   steps:
@@ -8,6 +8,6 @@ runs:
       with:
         github_access_token: ${{ github.token }}
 
-    - name: Load Nix development environment
+    - name: Install JavaScript dependencies
       shell: bash
-      run: nix develop --command true
+      run: nix develop .#ci --command vp install --frozen-lockfile

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -8,6 +8,10 @@ runs:
       with:
         github_access_token: ${{ github.token }}
 
-    - name: Install JavaScript dependencies
+    - name: Load CI tools and install JavaScript dependencies
       shell: bash
-      run: nix develop .#ci --command pnpm install --frozen-lockfile
+      run: |
+        nix develop .#ci --command bash -c '
+          pnpm install --frozen-lockfile
+          printf "%s\\n" "$PATH" | tr ":" "\\n" >> "$GITHUB_PATH"
+        '

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -10,4 +10,4 @@ runs:
 
     - name: Install JavaScript dependencies
       shell: bash
-      run: nix develop .#ci --command vp install --frozen-lockfile
+      run: nix develop .#ci --command pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,16 +21,16 @@ jobs:
         uses: ./.github/actions/setup-nix
 
       - name: Run Gitleaks
-        run: nix develop .#ci --command gitleaks detect --source . --config .gitleaks.toml
+        run: gitleaks detect --source . --config .gitleaks.toml
 
       - name: Run Typo Check
-        run: nix develop .#ci --command pnpm run typos
+        run: pnpm run typos
 
       - name: Run Vite+ Check
-        run: nix develop .#ci --command pnpm run check
+        run: pnpm run check
 
       - name: Run Tests
-        run: nix develop .#ci --command pnpm run test
+        run: pnpm run test
 
   action-timeline:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,13 +24,13 @@ jobs:
         run: nix develop .#ci --command gitleaks detect --source . --config .gitleaks.toml
 
       - name: Run Typo Check
-        run: nix develop .#ci --command vp run typos
+        run: nix develop .#ci --command pnpm run typos
 
       - name: Run Vite+ Check
-        run: nix develop .#ci --command vp check
+        run: nix develop .#ci --command pnpm run check
 
       - name: Run Tests
-        run: nix develop .#ci --command vp test --run
+        run: nix develop .#ci --command pnpm run test
 
   action-timeline:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,16 +21,16 @@ jobs:
         uses: ./.github/actions/setup-nix
 
       - name: Run Gitleaks
-        run: nix develop --command gitleaks detect --source . --config .gitleaks.toml
+        run: nix develop .#ci --command gitleaks detect --source . --config .gitleaks.toml
 
       - name: Run Typo Check
-        run: nix develop --command vp run typos
+        run: nix develop .#ci --command vp run typos
 
       - name: Run Vite+ Check
-        run: nix develop --command vp check
+        run: nix develop .#ci --command vp check
 
       - name: Run Tests
-        run: nix develop --command vp test --run
+        run: nix develop .#ci --command vp test --run
 
   action-timeline:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,17 +20,15 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
-      - name: Run Gitleaks
-        run: gitleaks detect --source . --config .gitleaks.toml
-
-      - name: Run Typo Check
-        run: pnpm run typos
-
-      - name: Run Vite+ Check
-        run: pnpm run check
-
-      - name: Run Tests
-        run: pnpm run test
+      - parallel:
+          - name: Run Gitleaks
+            run: gitleaks detect --source . --config .gitleaks.toml
+          - name: Run Typo Check
+            run: pnpm run typos
+          - name: Run Vite+ Check
+            run: pnpm run check
+          - name: Run Tests
+            run: pnpm run test
 
   action-timeline:
     needs:

--- a/flake.nix
+++ b/flake.nix
@@ -49,48 +49,60 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          agentSkills = agentSkillsFor system;
         in
         {
-          default = pkgs.mkShellNoCC {
-            # The driver's browser revision must match the repo's `playwright`,
-            # so bump the nixpkgs input alongside it.
-            PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
-            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
-
+          ci = pkgs.mkShellNoCC {
             buildInputs = [
               pkgs.nodejs_24
               nix-vite-plus.packages.${system}.vp
-            ] ++ (with pkgs; [
-              gitleaks
-              nushell
-              nufmt
-              typos
-              typos-lsp
-              svelte-language-server
-              yaml-language-server
-              gh
-              wrangler
-            ]);
-
-            shellHook = ''
-              if [ ! -f node_modules/.pnpm/lock.yaml ] || [ pnpm-lock.yaml -nt node_modules/.pnpm/lock.yaml ]; then
-                echo "📦 Installing dependencies..."
-                vp install --frozen-lockfile
-              fi
-
-              if [ -f .env.example ]; then
-                if [ ! -f .env ]; then
-                  echo "📝 Generating .env from .env.example..."
-                  cp .env.example .env
-                elif [ .env.example -nt .env ]; then
-                  echo "⚠️  .env.example has been updated, please review and update .env manually"
-                fi
-              fi
-
-              ${nixpkgs.lib.getExe agentSkills.syncAgentSkills}
-            '';
+              pkgs.gitleaks
+              pkgs.typos
+            ];
           };
+
+          default =
+            let
+              agentSkills = agentSkillsFor system;
+            in
+            pkgs.mkShellNoCC {
+              # The driver's browser revision must match the repo's `playwright`,
+              # so bump the nixpkgs input alongside it.
+              PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+              buildInputs = [
+                pkgs.nodejs_24
+                nix-vite-plus.packages.${system}.vp
+              ] ++ (with pkgs; [
+                gitleaks
+                nushell
+                nufmt
+                typos
+                typos-lsp
+                svelte-language-server
+                yaml-language-server
+                gh
+                wrangler
+              ]);
+
+              shellHook = ''
+                if [ ! -f node_modules/.pnpm/lock.yaml ] || [ pnpm-lock.yaml -nt node_modules/.pnpm/lock.yaml ]; then
+                  echo "📦 Installing dependencies..."
+                  vp install --frozen-lockfile
+                fi
+
+                if [ -f .env.example ]; then
+                  if [ ! -f .env ]; then
+                    echo "📝 Generating .env from .env.example..."
+                    cp .env.example .env
+                  elif [ .env.example -nt .env ]; then
+                    echo "⚠️  .env.example has been updated, please review and update .env manually"
+                  fi
+                fi
+
+                ${nixpkgs.lib.getExe agentSkills.syncAgentSkills}
+              '';
+            };
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -49,15 +49,17 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          baseBuildInputs = with pkgs; [
+            nodejs_24
+            gitleaks
+            typos
+          ];
         in
         {
           ci = pkgs.mkShellNoCC {
-            buildInputs = [
-              pkgs.nodejs_24
-              pkgs.pnpm
-              pkgs.gitleaks
-              pkgs.typos
-            ];
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+            buildInputs = baseBuildInputs ++ [ pkgs.pnpm ];
           };
 
           default =
@@ -70,14 +72,9 @@
               PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
               PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
 
-              buildInputs = [
-                pkgs.nodejs_24
-                nix-vite-plus.packages.${system}.vp
-              ] ++ (with pkgs; [
-                gitleaks
+              buildInputs = baseBuildInputs ++ [ nix-vite-plus.packages.${system}.vp ] ++ (with pkgs; [
                 nushell
                 nufmt
-                typos
                 typos-lsp
                 svelte-language-server
                 yaml-language-server

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           ci = pkgs.mkShellNoCC {
             buildInputs = [
               pkgs.nodejs_24
-              nix-vite-plus.packages.${system}.vp
+              pkgs.pnpm
               pkgs.gitleaks
               pkgs.typos
             ];


### PR DESCRIPTION
## Summary

Reduce CI startup time by separating the local development shell from a minimal CI Nix shell and avoiding repeated Nix shell entry.

## What changed

- Add a `.#ci` devShell containing only Node.js, pnpm, Gitleaks, and Typos.
- Keep the full local development shell, including agent skills, browser assets, language servers, deployment tooling, and the Nix Vite+ package.
- Install dependencies with pnpm and run the Vite+ binary from the project lockfile.
- Export the CI shell PATH once so later checks reuse the same Nix-provided tools without re-entering `nix develop`.
- Disable Playwright browser downloads in the CI shell.
- Share the common tool list between the local and CI shells.

## Measurements

- Baseline main runs spent about 147–152 seconds in `Setup Nix`.
- The first minimal-shell iteration showed that the Nix Vite+ closure was still the dominant cost.
- The final run spent 42.8 seconds in `Setup Nix`, a roughly 71% reduction.
- Nix installation took less than one second; the remaining setup time was primarily the locked pnpm install.

## Testing

- `gh-nix nix flake check --no-build`
- Gitleaks
- Typos
- Vite+ format, lint, and type check
- 34 test files / 218 tests
- Two successful GitHub Actions CI runs on the final implementation
