### PR TITLE
fix(about): update ccusage link

### DIFF
--- a/src/site/templates/About.svelte
+++ b/src/site/templates/About.svelte
@@ -52,7 +52,7 @@
 					<span class='font-semibold text-text-800 dark:text-text-100'>{SITE_OWNER.handle.slice(1)}</span>
 					<span class='font-mono text-sm text-text-400'>({SITE_OWNER.name} / <span lang='ja'>{SITE_OWNER.japaneseName}</span>)</span>
 					builds coding agents, developer tools, and human-centred AI products. Maintains
-					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://github.com/ryoppippi/ccusage' rel='noopener noreferrer' target='_blank'>ccusage</a>
+					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='https://ccusage.com/gh' rel='noopener noreferrer' target='_blank'>ccusage</a>
 					and
 					<a class='font-medium text-inherit underline decoration-[#8886] underline-offset-4 transition-base hover:decoration-accent-100' href='/works/oss/'>other open-source projects</a>.
 					<span class='font-medium text-text-700 dark:text-text-200'>Founding Engineer</span> at


### PR DESCRIPTION
Updates the ccusage link in the About page to https://ccusage.com/gh.

This keeps the profile link on the project’s canonical redirect.

Tests: `pnpm test -- src/site/secondary-pages.ts` (218 tests passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the About page’s `ccusage` link to point to the new website URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->