### PR TITLE
fix(oss): use a daily-report icon for gh-nippou

### DIFF
--- a/src/contents/works/oss/list.json
+++ b/src/contents/works/oss/list.json
@@ -154,7 +154,7 @@
 	},
 	{
 		"name": "gh-nippou",
-		"icon": "icon-[simple-icons--github]",
+		"icon": "icon-[material-symbols--edit-document-outline]",
 		"tags": ["GitHub", "CLI"],
 		"description": "GitHub CLI extension for generating daily reports from GitHub activity."
 	},


### PR DESCRIPTION
The gh-nippou portfolio entry used the GitHub logo, which identified the hosting platform rather than the tool's purpose.

Use the existing edit-document icon so the entry communicates that gh-nippou generates daily reports.

Validation: `jq empty src/contents/works/oss/list.json` and `git diff --check`.
