### PR TITLE
refactor(site): use ufo for generated URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"svelte": "^5.56.8",
 		"tailwindcss": "^4.3.3",
 		"tinyglobby": "^0.2.17",
+		"ufo": "^1.6.4",
 		"unhead": "3.4.0",
 		"vite": "npm:@voidzero-dev/vite-plus-core@0.2.9",
 		"vite-plugin-solid": "^2.11.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
+      ufo:
+        specifier: ^1.6.4
+        version: 1.6.4
       unhead:
         specifier: 3.4.0
         version: 3.4.0(@voidzero-dev/vite-plus-core@0.2.9(@types/node@24.13.3)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(rolldown@1.1.2)

--- a/src/site/consts.ts
+++ b/src/site/consts.ts
@@ -1,3 +1,5 @@
+import * as ufo from 'ufo';
+
 const DEFAULT_SITE_ORIGIN = 'https://ryoppippi.com';
 
 /**
@@ -13,7 +15,7 @@ export const SITE_NAME = 'ryoppippi.com';
 /**
  * JPEG URL used by social cards and feed metadata for broad consumer compatibility.
  */
-export const SITE_SOCIAL_IMAGE_URL = `${SITE_ORIGIN}/ryoppippi.jpg`;
+export const SITE_SOCIAL_IMAGE_URL = ufo.joinURL(SITE_ORIGIN, 'ryoppippi.jpg');
 
 /** The licence, period, and holder applied to original blog content. */
 export const SITE_COPYRIGHT = 'CC BY-NC-SA 4.0 2022-PRESENT © ryoppippi';

--- a/src/site/generate.ts
+++ b/src/site/generate.ts
@@ -2,6 +2,7 @@ import type { ContentArtifact, TweetRenderer } from '@ryoppippi/content';
 import type { GeneratedFile } from './pages.ts';
 import type { SiteAssets } from './assets.ts';
 import { blogDirectory, showcaseDirectory } from '@ryoppippi/content/paths';
+import * as ufo from 'ufo';
 import { access, mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
@@ -122,7 +123,7 @@ export async function generateSite({
 	const plainFiles: GeneratedFile[] = [
 		{
 			path: 'works/index.html',
-			content: `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="refresh" content="0;url=/works/oss/"><link rel="canonical" href="${SITE_ORIGIN}/works/oss/"><title>Redirecting to works</title></head><body><a href="/works/oss/">Continue to works</a></body></html>`,
+			content: `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="refresh" content="0;url=/works/oss/"><link rel="canonical" href="${ufo.joinURL(SITE_ORIGIN, 'works/oss/')}"><title>Redirecting to works</title></head><body><a href="/works/oss/">Continue to works</a></body></html>`,
 		},
 		{ path: 'dotfiles.md', content: dotfiles },
 		{ path: 'dotfiles/install', content: install },
@@ -142,7 +143,9 @@ export async function generateSite({
 	const urls = pages.filter((file) => file.path.endsWith('.html') && file.path !== '404.html');
 	const sitemapEntries = await Promise.all(
 		urls.map(async (file) => {
-			const loc = `${SITE_ORIGIN}/${file.path.replace(/(?:index)?\.html$/, '')}`;
+			const loc = ufo.withTrailingSlash(
+				ufo.joinURL(SITE_ORIGIN, file.path.replace(/(?:index)?\.html$/, '')),
+			);
 			const lastmod = await gitLastModified(root, file.sourcePaths ?? []);
 			return lastmod == null ? { loc } : { loc, lastmod };
 		}),

--- a/src/site/pages.ts
+++ b/src/site/pages.ts
@@ -2,6 +2,7 @@ import type { ArticleMetadata, BlogPost, BlogPostMetadata } from '@ryoppippi/con
 import type { SiteAssets } from './assets.ts';
 import type { PostListItem } from './content.ts';
 import { Feed } from 'feed';
+import * as ufo from 'ufo';
 import { formatDate } from '../lib/util.ts';
 import { islandModuleIds } from './assets.ts';
 import { SITE_COPYRIGHT, SITE_NAME, SITE_ORIGIN, SITE_SOCIAL_IMAGE_URL } from './consts.ts';
@@ -89,7 +90,7 @@ export function homePage(assets: SiteAssets): GeneratedFile {
 				'@graph': [
 					{
 						'@type': 'WebSite',
-						'@id': `${SITE_ORIGIN}/#website`,
+						'@id': ufo.withFragment(ufo.withTrailingSlash(SITE_ORIGIN), 'website'),
 						name: SITE_NAME,
 						alternateName: SITE_OWNER.handle,
 						description: HOME_DESCRIPTION,
@@ -98,9 +99,11 @@ export function homePage(assets: SiteAssets): GeneratedFile {
 					},
 					{
 						'@type': 'ProfilePage',
-						'@id': `${SITE_ORIGIN}/#profile`,
+						'@id': ufo.withFragment(ufo.withTrailingSlash(SITE_ORIGIN), 'profile'),
 						url: SITE_OWNER.url,
-						isPartOf: { '@id': `${SITE_ORIGIN}/#website` },
+						isPartOf: {
+							'@id': ufo.withFragment(ufo.withTrailingSlash(SITE_ORIGIN), 'website'),
+						},
 						mainEntity: { '@id': SITE_OWNER.id },
 					},
 					{
@@ -163,7 +166,7 @@ export function blogListPage(items: PostListItem[], assets: SiteAssets): Generat
  */
 export function articlePages(post: BlogPost, assets: SiteAssets): GeneratedFile[] {
 	const pathname = `/blog/${post.filename}/`;
-	const url = `${SITE_ORIGIN}${pathname}`;
+	const url = ufo.joinURL(SITE_ORIGIN, pathname);
 	const metadata = articleSeoMetadata(post);
 	const image =
 		metadata.image == null ? articleImageUrl(post.html, url) : new URL(metadata.image, url).href;
@@ -231,12 +234,12 @@ export function feed(posts: BlogPostMetadata[]): GeneratedFile {
 		image: SITE_SOCIAL_IMAGE_URL,
 		favicon: SITE_SOCIAL_IMAGE_URL,
 		copyright: SITE_COPYRIGHT,
-		feedLinks: { rss: `${SITE_ORIGIN}/feed.xml` },
+		feedLinks: { rss: ufo.joinURL(SITE_ORIGIN, 'feed.xml') },
 	});
 	for (const post of posts.filter((post) => post.isPublished)) {
 		output.addItem({
 			title: post.title,
-			link: `${SITE_ORIGIN}/blog/${post.filename}/`,
+			link: ufo.joinURL(SITE_ORIGIN, 'blog', `${post.filename}/`),
 			date: new Date(post.pubDate),
 			description: `${post.title} | ${post.readingTime.text}`,
 		});
@@ -252,7 +255,7 @@ export function feed(posts: BlogPostMetadata[]): GeneratedFile {
  */
 export function mediaFeed(items: PostListItem[]): GeneratedFile {
 	const pathname = '/works/media/';
-	const url = `${SITE_ORIGIN}${pathname}`;
+	const url = ufo.joinURL(SITE_ORIGIN, pathname);
 	const output = new Feed({
 		title: `Media | ${SITE_NAME}`,
 		description: `Media appearances by ${SITE_NAME}`,
@@ -262,7 +265,7 @@ export function mediaFeed(items: PostListItem[]): GeneratedFile {
 		image: SITE_SOCIAL_IMAGE_URL,
 		favicon: SITE_SOCIAL_IMAGE_URL,
 		copyright: SITE_COPYRIGHT,
-		feedLinks: { rss: `${url}feed.xml` },
+		feedLinks: { rss: ufo.joinURL(url, 'feed.xml') },
 	});
 	for (const item of items.filter((item) => item.playlist !== true)) {
 		output.addItem({

--- a/src/site/secondary-pages.ts
+++ b/src/site/secondary-pages.ts
@@ -5,6 +5,7 @@ import type { GeneratedFile } from './pages.ts';
 import type { OssProject, Talk } from './sections.ts';
 import { SITE_ORIGIN } from './consts.ts';
 import { SITE_OWNER } from './site-owner.ts';
+import * as ufo from 'ufo';
 import { page, renderComponent } from './html.ts';
 import About from './templates/About.svelte';
 import ErrorPage from './templates/Error.svelte';
@@ -29,7 +30,7 @@ const ABOUT_DESCRIPTION =
  * @returns The generated About page.
  */
 export function aboutPage(assets: SiteAssets): GeneratedFile {
-	const url = `${SITE_ORIGIN}${ABOUT_PATHNAME}`;
+	const url = ufo.joinURL(SITE_ORIGIN, ABOUT_PATHNAME);
 	return {
 		path: 'about/index.html',
 		sourcePaths: ['src/site/site-owner.ts', 'src/site/templates/About.svelte'],
@@ -43,7 +44,7 @@ export function aboutPage(assets: SiteAssets): GeneratedFile {
 			structuredData: {
 				'@context': 'https://schema.org',
 				'@type': 'ProfilePage',
-				'@id': `${url}#profile`,
+				'@id': ufo.withFragment(url, 'profile'),
 				url,
 				name: ABOUT_TITLE,
 				description: ABOUT_DESCRIPTION,
@@ -65,7 +66,7 @@ export function aboutPage(assets: SiteAssets): GeneratedFile {
 						SITE_OWNER.handle,
 					],
 					url: SITE_OWNER.url,
-					image: `${SITE_ORIGIN}/ryoppippi.avif`,
+					image: ufo.joinURL(SITE_ORIGIN, 'ryoppippi.avif'),
 					sameAs: [...SITE_OWNER.sameAs],
 				},
 			},


### PR DESCRIPTION
Use `ufo` for URL and fragment composition across static page, feed, redirect, and sitemap generation. Keep `SITE_SOCIAL_IMAGE_URL` in the shared constants module while declaring `ufo` as a development dependency for the build-time path.

The browser entrypoint does not import `ufo`, and the generated browser JavaScript contains no `ufo` or `joinURL` references.

Tests:
- `pnpm format`
- `pnpm test`
- `pnpm build`
- `xmllint --noout build/sitemap.xml`
