### PR TITLE
fix(markdown): preserve multiple link preview cards

### DIFF
--- a/packages/content/src/markdown/link-preview.ts
+++ b/packages/content/src/markdown/link-preview.ts
@@ -6,7 +6,7 @@ export function replaceLinkPreviews(line: string) {
 	return line.replace(linkPreviewPattern, (match, url: string) => {
 		try {
 			new URL(url);
-			return `<OgCard url="${escapeHtml(url)}" />`;
+			return `<OgCard url="${escapeHtml(url)}"></OgCard>`;
 		} catch {
 			return match;
 		}
@@ -17,7 +17,7 @@ if (import.meta.vitest != null) {
 	describe('replaceLinkPreviews', () => {
 		it('converts preview links to open graph embeds', () => {
 			expect(replaceLinkPreviews('[@preview](https://example.com/post)')).toBe(
-				'<OgCard url="https://example.com/post" />',
+				'<OgCard url="https://example.com/post"></OgCard>',
 			);
 		});
 

--- a/packages/content/src/markdown/render.ts
+++ b/packages/content/src/markdown/render.ts
@@ -308,6 +308,17 @@ if (import.meta.vitest != null) {
 			expect(html).toContain('href="https://example.com/post"');
 		});
 
+		it('renders consecutive preview links as separate cards', async () => {
+			const html = await renderMarkdown(
+				'[@preview](https://example.com/first)\n\n[@preview](https://example.com/second)',
+				{ openGraph: {} },
+			);
+
+			expect(html.match(/class="ox-ogp-simple"/g)).toHaveLength(2);
+			expect(html).toContain('href="https://example.com/first"');
+			expect(html).toContain('href="https://example.com/second"');
+		});
+
 		it('separates a preview card from preceding prose', async () => {
 			const url = 'https://example.com/post';
 			const html = await renderMarkdown(`説明文\n[@preview](${url})`, {
@@ -345,7 +356,7 @@ if (import.meta.vitest != null) {
 
 		it('converts preview links to link card html', () => {
 			expect(prepareOxContentMarkdown('[@preview](https://github.com/junkawa/figma_jp)')).toBe(
-				'<OgCard url="https://github.com/junkawa/figma_jp" />',
+				'<OgCard url="https://github.com/junkawa/figma_jp"></OgCard>',
 			);
 		});
 


### PR DESCRIPTION
This fixes link preview rendering when an article contains multiple `[@preview](...)` links. The generated `OgCard` elements now use explicit closing tags so the HTML parser does not nest adjacent cards and drop later previews.

Tests:
- `pnpm exec vitest run packages/content/src/markdown/link-preview.ts packages/content/src/markdown/render.ts`
- `pnpm check`
