### PR TITLE
chore(nix): silence agent skills sync output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
                   fi
                 fi
 
-                ${nixpkgs.lib.getExe agentSkills.syncAgentSkills}
+                ${nixpkgs.lib.getExe agentSkills.syncAgentSkills} >/dev/null
               '';
             };
         }


### PR DESCRIPTION
Redirects successful output from the project-local agent skills synchroniser when the development shell starts.
This prevents the agent-skills installation status line from appearing while retaining stderr for failures.
Verified with nix-instantiate --parse flake.nix and git diff --check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the agent skills synchroniser output when the dev shell starts so the installation status line no longer clogs the terminal. Failures still print to stderr as before.

<sup>Written for commit 284462e53f731762cab274c8efecc3fc48d07bd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced unnecessary command-line output during development environment setup while preserving synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->