### PR TITLE
fix(devshell): silence agent-skills sync output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
                   fi
                 fi
 
-                ${nixpkgs.lib.getExe agentSkills.syncAgentSkills}
+                AGENT_SKILLS_QUIET=1 ${nixpkgs.lib.getExe agentSkills.syncAgentSkills}
               '';
             };
         }


### PR DESCRIPTION
The development shell now runs the agent-skills synchronisation step in quiet mode.

Routine successful installs no longer print a status line on every shell entry, while warnings and failures remain visible.

Testing: nix-instantiate --parse flake.nix; git diff --check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the dev shell's agent-skills sync in quiet mode so routine successful installs no longer print a status line on every shell entry. Warnings and failures remain visible.

<sup>Written for commit b71b22deae2eb49332132252645970c53d4fa275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced output displayed when entering the development shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->