### PR TITLE
chore(nix): adopt quiet agent skills shell hook

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786379373,
-        "narHash": "sha256-zrvcpGFA8zG6yRLBqQH9bNkJap8xMvLNvkuT4+7w6X8=",
+        "lastModified": 1788359763,
+        "narHash": "sha256-fSf98BvLBbAPeBiI14hxH0pw0ewb5RGtQxcm0vANkSM=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "1594ba479be81a7cb6dd19faabefcb1ed5b3f964",
+        "rev": "260294fa7b7b8083006a959f1b36be77b24912dc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
                   fi
                 fi
 
-                ${nixpkgs.lib.getExe agentSkills.syncAgentSkills} >/dev/null
+                ${agentSkills.shellHook}
               '';
             };
         }

--- a/nix/agent-skills.nix
+++ b/nix/agent-skills.nix
@@ -32,6 +32,11 @@ let
       structure = "link";
     };
   };
+  shellHook = agentLib.mkShellHook {
+    inherit pkgs bundle;
+    targets = localTargets;
+    quiet = true;
+  };
   installLocal = agentLib.mkLocalInstallScript {
     inherit pkgs bundle;
     targets = localTargets;
@@ -49,10 +54,10 @@ let
         echo "Remove it before syncing Nix-managed agent skills." >&2
         exit 1
       fi
-      exec skills-install-local "$@" >/dev/null
+      exec skills-install-local "$@"
     '';
   };
 in
 {
-  inherit bundle syncAgentSkills;
+  inherit bundle shellHook syncAgentSkills;
 }


### PR DESCRIPTION
Update the pinned agent-skills-nix input to the latest upstream revision and use its supported quiet shell hook for project-local skill synchronisation. The standalone sync app keeps normal progress output, while repeated dev-shell entry suppresses only successful progress lines.

Tests: `nix flake check`, `nix build .#agent-skills-bundle --no-link`, `pnpm run check`, `pnpm run test`, `pnpm run build`, `pnpm run typos`, and `gitleaks detect`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pinned `agent-skills-nix` input to the latest upstream revision and replaces the dev-shell skill sync command with its supported quiet shell hook. The standalone sync app keeps normal progress output, while repeated dev-shell entry now suppresses only successful progress lines.

<sup>Written for commit 212e68509985b8456e7bc2793092f81540edd890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Development shells now automatically prepare local Claude skills when launched.
  - Skill installation progress is visible instead of being hidden.

- **Bug Fixes**
  - Improved consistency between development-shell setup and the local skill installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->