### PR TITLE
fix(hooks): stop tracking generated Vite hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ vite.config.ts.timestamp-*
 /static/_redirects
 /src/lib/assets/favicons.html
 /.vite-inspect
+/.vite-hooks/
 /.eslintrc-components.json
 
 # Generated local agent skills

--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,1 +1,0 @@
-exec nix develop --command vp staged


### PR DESCRIPTION
## Summary

- Remove the tracked `.vite-hooks/pre-commit` script from the repository.
- Ignore `/.vite-hooks/` so local Vite+ hook files are not committed again.
- No runtime, package, or Vite configuration changes are included.

## Testing

- nix develop . --command vp check
- nix develop . --command vp hooks status


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tracking the generated `/.vite-hooks/pre-commit` hook so local Vite+ hook files stay out of repository history.

- Removes the committed `.vite-hooks/pre-commit` script.
- Ignores `/.vite-hooks/` to prevent future commits.
- No runtime, package, or Vite configuration changes.

<sup>Written for commit 850628291aa86ce14d5fd78946dc13cf237ed76d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

