### PR TITLE
ci: add weekly link check reports

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,0 +1,46 @@
+name: Check Links
+
+on:
+  workflow_dispatch:
+  schedule:
+    # External links can break without a repository change.
+    - cron: '23 6 * * 1'
+
+concurrency:
+  group: check-links
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-links:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Check Markdown links
+        id: lychee
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          # Report failures while exclusions are calibrated against real results.
+          fail: false
+          jobSummary: true
+          format: markdown
+          args: >-
+            --scheme http --scheme https
+            --exclude-all-private
+            --max-concurrency 8
+            --host-concurrency 2
+            --max-retries 2
+            --timeout 20
+            --no-progress
+            -- README.md 'src/content/**/*.md'
+
+      - name: Fail on checker errors
+        if: steps.lychee.outputs.exit_code != '0' && steps.lychee.outputs.exit_code != '2'
+        run: exit 1


### PR DESCRIPTION
External links in older articles can break without any repository changes. Add a weekly Monday 06:23 UTC and manually triggered lychee workflow that checks HTTP(S) links in README and content Markdown and publishes a Markdown job summary.

Link failures remain report-only; execution and configuration errors fail the job. Pin the official action, limit request concurrency and retries, and exclude private addresses.

Validation: actionlint, formatting with the repository's quote/indent settings, staged Gitleaks, full input extraction, and a live two-link Showcase sample passed; an independent review found no actionable issues. The complete scheduled scan will run after merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a weekly link check workflow that reports broken HTTP(S) links in README and content Markdown without failing the job.

- Runs Monday 06:23 UTC and can be triggered manually.
- Broken links appear in the job summary; checker and configuration errors fail the job.
- Excludes private addresses and limits concurrency and retries.

<sup>Written for commit d25e9baa42781b70411ffa068f4c37fb82c21fa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated link checks for the README and Markdown content.
  * Link checks run weekly and can also be triggered manually.
  * Results are reported in the workflow summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->