### PR TITLE
fix(blog): centre titles alongside entry icons

### DIFF
--- a/src/pages/blog/BlogList.module.css
+++ b/src/pages/blog/BlogList.module.css
@@ -77,6 +77,7 @@
 
 .blogEntryDate {
 	display: inline-block;
+	vertical-align: middle;
 	max-width: 100%;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
The inline-block date was expanding the title line box, making blog titles appear below the centre of their icons. Set the date to vertical-align: middle so the existing flex centring can align each entry correctly.

Validation: git diff --check passed. Post-change visual verification could not be completed because the local server refused the connection.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blog list entry alignment so titles now appear vertically centered alongside their icons. The date element's inline-block box was expanding the title line box and pushing titles below center; setting `vertical-align: middle` lets the existing flex centering align each entry correctly.

<sup>Written for commit 9830bb43a2d833305f47277aa4f55db3b4e2afa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical alignment of blog entry dates for more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->