### PR TITLE
fix(metadata): use lowercase page titles

### DIFF
--- a/src/pages/404.html/index.ts
+++ b/src/pages/404.html/index.ts
@@ -20,7 +20,7 @@ export function createErrorPageFile(assets: SiteAssets) {
 		componentProps: {},
 		outputPath: '404.html',
 		sourcePaths: ['src/pages/404.html'],
-		title: 'Page not found',
+		title: 'page not found',
 		pathname: '/404',
 		description: 'The requested page could not be found.',
 		indexable: false,

--- a/src/pages/about/index.ts
+++ b/src/pages/about/index.ts
@@ -12,7 +12,8 @@ export const routes = (() => [
 ]) satisfies PageRoutes;
 
 const ABOUT_PATHNAME = '/about/';
-const ABOUT_TITLE = 'ryoppippi (Ryotaro Kimura)';
+const ABOUT_TITLE = 'about';
+const ABOUT_PROFILE_NAME = 'ryoppippi (Ryotaro Kimura)';
 const ABOUT_DESCRIPTION =
 	'Ryotaro Kimura (木村亮太朗), known as ryoppippi, builds developer tools, maintains ccusage and open-source projects, and is a Founding Engineer at Rork.';
 
@@ -39,7 +40,7 @@ export function createAboutPageFile(assets: SiteAssets) {
 			'@type': 'ProfilePage',
 			'@id': ufo.withFragment(url, 'profile'),
 			url,
-			name: ABOUT_TITLE,
+			name: ABOUT_PROFILE_NAME,
 			description: ABOUT_DESCRIPTION,
 			mainEntity: {
 				'@type': 'Person',

--- a/src/pages/blog/index.ts
+++ b/src/pages/blog/index.ts
@@ -42,7 +42,7 @@ export function createBlogListPageFile(items: PostListItem[], assets: SiteAssets
 			'src/content/blog/external/rss.json',
 			'src/content/blog/external/posts.json',
 		],
-		title: 'Blog',
+		title: 'blog',
 		pathname: '/blog/',
 		description:
 			'Technical articles by @ryoppippi about software engineering, developer tooling, open source, and AI.',

--- a/src/pages/sponsors/index.ts
+++ b/src/pages/sponsors/index.ts
@@ -20,7 +20,7 @@ export function createSponsorsPageFile(assets: SiteAssets) {
 		componentProps: {},
 		outputPath: 'sponsors/index.html',
 		sourcePaths: ['src/pages/sponsors'],
-		title: 'Sponsors',
+		title: 'sponsors',
 		pathname: '/sponsors/',
 		description:
 			"Support @ryoppippi's open-source projects, technical writing, and talks through GitHub Sponsors.",

--- a/src/pages/works/media/feed.ts
+++ b/src/pages/works/media/feed.ts
@@ -7,7 +7,7 @@ export const MEDIA_FEED_OPTIONS = {
 	formats: ['rss'],
 	limit: 1_000,
 	path: '/works/media',
-	title: `Media | ${SITE_NAME}`,
+	title: `media | ${SITE_NAME}`,
 	description: `Media appearances by ${SITE_NAME}`,
 	language: 'ja',
 	image: SITE_SOCIAL_IMAGE_URL,

--- a/src/pages/works/media/index.ts
+++ b/src/pages/works/media/index.ts
@@ -34,7 +34,7 @@ export function createMediaPageFile(items: PostListItem[], assets: SiteAssets) {
 			'src/pages/works/media',
 			'src/content/works/media/list.json',
 		],
-		title: 'Media',
+		title: 'media',
 		pathname: '/works/media/',
 		description: 'Podcasts, interviews, and videos featuring @ryoppippi.',
 		assets,

--- a/src/pages/works/oss/index.ts
+++ b/src/pages/works/oss/index.ts
@@ -33,7 +33,7 @@ export function createOssPageFile(projects: OssProject[], assets: SiteAssets) {
 			'src/content/works/oss/list.json',
 			'src/content/works/oss/stars.json',
 		],
-		title: 'Open-source projects',
+		title: 'open-source projects',
 		pathname: '/works/oss/',
 		description:
 			'Open-source projects by @ryoppippi across AI tools, Nix, TypeScript, Svelte, Vim, Zig, and shell configuration.',

--- a/src/pages/works/publications/index.ts
+++ b/src/pages/works/publications/index.ts
@@ -38,7 +38,7 @@ export function createPublicationsPageFile(
 			'src/pages/works/publications',
 			'src/content/works/publications/list.json',
 		],
-		title: 'Publications',
+		title: 'publications',
 		pathname: '/works/publications/',
 		description:
 			'Research papers and technical publications authored or co-authored by @ryoppippi.',

--- a/src/pages/works/showcase/index.ts
+++ b/src/pages/works/showcase/index.ts
@@ -33,7 +33,7 @@ export function createShowcasePageFile(projects: ShowcaseProject[], assets: Site
 			'src/pages/works/showcase/data.ts',
 			'src/content/works/showcase',
 		],
-		title: 'Project showcase',
+		title: 'project showcase',
 		pathname: '/works/showcase/',
 		description:
 			'Selected projects and experiments by @ryoppippi, with demos, source links, and implementation notes.',

--- a/src/pages/works/talks/index.ts
+++ b/src/pages/works/talks/index.ts
@@ -31,7 +31,7 @@ export function createTalksPageFile(talks: Talk[], assets: SiteAssets) {
 			'src/components/WorksNav/WorksProse.css',
 			'src/pages/works/talks',
 		],
-		title: 'Talks',
+		title: 'talks',
 		pathname: '/works/talks/',
 		description:
 			'Conference talks and presentations by @ryoppippi, with event links, slides, and videos.',


### PR DESCRIPTION
Lowercase the static page labels used in document titles so pages follow the site's existing lowercase style, including about | ryoppippi.com. Keep the profile name in structured data unchanged while aligning the media RSS title as well. Verification: direnv exec . pnpm check and direnv exec . pnpm build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowercases static page titles so document titles follow the site's existing lowercase style, including `about | ryoppippi.com`.

- Keeps the profile name in the about page structured data unchanged.
- Aligns the media RSS feed title with the lowercase style.

<sup>Written for commit 8631fc25404a0c60fc40dd1212d14fff114f108a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

