### PR TITLE
ci: remove actions-timeline workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
   pull_request:
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
@@ -29,11 +28,3 @@ jobs:
             run: pnpm run check
           - name: Run Tests
             run: pnpm run test
-
-  action-timeline:
-    needs:
-      - ci
-    if: ${{ always() }}
-    runs-on: ubuntu-slim
-    steps:
-      - uses: Kesin11/actions-timeline@57fc93f20c6da7fbc14063c6d24a2a5627c799ad # v3.2


### PR DESCRIPTION
Remove the actions-timeline job from CI and drop the now-unused actions: write workflow permission.

Validation:
- Ruby YAML parser
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `action-timeline` job from CI and drops the now-unused `actions: write` workflow permission.

<sup>Written for commit 9516827e4cf663ba2b8aff150636b662d0802193. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced workflow permissions to read-only repository access.
  - Removed the action timeline reporting job from continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->