### PR TITLE
feat(content): generate new posts as MDX

### DIFF
--- a/scripts/new-post.ts
+++ b/scripts/new-post.ts
@@ -35,7 +35,7 @@ p.log.message('Creating post...');
 const blogDir = BLOG_DIRECTORY;
 const slug = `${date}-${title.toLowerCase().replace(/ /g, '-')}-${lang}`;
 const postDir = join(blogDir, slug);
-const md = join(postDir, 'index.md');
+const mdx = join(postDir, 'index.mdx');
 const frontMatter = stringify('', {
 	title,
 	date,
@@ -44,16 +44,16 @@ const frontMatter = stringify('', {
 });
 
 await fs.ensureDir(postDir);
-await fs.writeFile(md, frontMatter);
+await fs.writeFile(mdx, frontMatter);
 
-p.log.success(`Post created at ${md}`);
+p.log.success(`Post created at ${mdx}`);
 
 const isOpen = await p.confirm({
 	message: 'Do you want to open the editor?',
 	initialValue: true,
 });
 if (isOpen === true) {
-	await openEditor([{ file: md }]);
+	await openEditor([{ file: mdx }]);
 }
 
 p.outro('Done!');


### PR DESCRIPTION
Change the new-post command to create blog posts as index.mdx by default.

The site already accepts MDX sources, so this keeps the generated file aligned with the supported authoring format. Checks, tests, typos, gitleaks, and the production build pass locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the new-post command to generate blog posts as `index.mdx` instead of `index.md`. The site already supports MDX, so generated files now match the supported authoring format.

<sup>Written for commit 6e0908a06fbed1603508db756bd93f7abdcea6cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Blog post creation now generates `.mdx` files instead of `.md` files.
  * Success messages and editor launching reflect the updated `.mdx` format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->