### PR TITLE
perf(build): adopt Ox Content 3.1.2 optimisations

### DIFF
--- a/docs/ox-content.md
+++ b/docs/ox-content.md
@@ -114,6 +114,22 @@ generated files are byte-for-byte identical to the pre-audit build. Remaining
 adapters are site composition, not reproduced framework machinery; this audit
 did not uncover a new upstream public-contract gap requiring an issue.
 
+## Pending: island discovery embed rendering
+
+[#1370](https://github.com/ubugeeei-prod/ox-content/issues/1370) tracks full embed
+rendering during Solid client-island discovery. The registry alone overrides
+`embeds: false`; the custom host retains the shared embed settings for page output.
+
+On 2026-09-08, Vite's reported client build fell from 10.75 s initially
+(1.47 s on a later warm run) to 692 ms / 674 ms with the override. These timings
+exclude the full CLI/SSG wall time. The generated output trees were byte-identical;
+428 custom-host outputs and the same client island were preserved. A build before
+the page-component rename also took 10.61 s with the same dependencies.
+
+Adopt an official upstream release when discovery no longer needs this override,
+remove it, and recheck build timing, generated output and client island behaviour.
+Issue closure alone is not proof that the fix has shipped.
+
 ## Remaining boundary
 
 All previously filed adoption gates are released and adopted. Site-owned

--- a/docs/ox-content.md
+++ b/docs/ox-content.md
@@ -132,14 +132,14 @@ selection, article link previews, and Tweet text/images on a fresh dev server.
 A source audit found no reproduced regression in the changed discovery/cache
 paths; CSS cache keys distinguish context and JS keys distinguish inline scripts.
 
-| Measurement | 3.1.2 |
-| --- | --- |
-| First build after dependency update, CLI wall | 3.97 s |
-| Subsequent warm build, CLI wall | 3.91 s |
-| Empty Vite cache, CLI wall | 4.08 s |
-| Vite-reported client build | 0.64-0.67 s |
-| Profiled HTML minification and writes | 0.24 s |
-| Profiled coordinated output writer | 0.57 s |
+| Measurement                                   | 3.1.2       |
+| --------------------------------------------- | ----------- |
+| First build after dependency update, CLI wall | 3.97 s      |
+| Subsequent warm build, CLI wall               | 3.91 s      |
+| Empty Vite cache, CLI wall                    | 4.08 s      |
+| Vite-reported client build                    | 0.64-0.67 s |
+| Profiled HTML minification and writes         | 0.24 s      |
+| Profiled coordinated output writer            | 0.57 s      |
 
 The Vite-cache-cold run retained the existing Ox Content embed cache; it is not
 a fully network-cold build. The previous 3.1.1 diagnostic samples measured

--- a/docs/ox-content.md
+++ b/docs/ox-content.md
@@ -130,6 +130,22 @@ Adopt an official upstream release when discovery no longer needs this override,
 remove it, and recheck build timing, generated output and client island behaviour.
 Issue closure alone is not proof that the fix has shipped.
 
+## Pending: custom-host output performance
+
+[#1371](https://github.com/ubugeeei-prod/ox-content/issues/1371) tracks production
+HTML minification performance. Warm diagnostic runs on 2026-09-08 measured route
+preparation at 1.42-1.56 s (blog rendering about 1.25 s), page rendering at
+0.17-0.25 s, output planning at 0.16 s and loader shutdown at 0.25-0.37 s.
+HTML minification plus writes took 0.57 s. Temporarily disabling only host HTML
+minification reduced coordinated output writing from 0.97 s to 0.39 s and CLI
+wall time from 4.90 s to 4.12 s. These are diagnostic samples, not a controlled
+benchmark; production minification remains enabled.
+
+Monitor and adopt supported upstream improvements while retaining HTML,
+hydration, inline CSS/JS and compression semantics. Measure total CLI/SSG time
+as well as Vite's client timing; do not equate client completion with full build
+completion.
+
 ## Remaining boundary
 
 All previously filed adoption gates are released and adopted. Site-owned

--- a/docs/ox-content.md
+++ b/docs/ox-content.md
@@ -1,6 +1,6 @@
 # Ox Content integration boundary
 
-The site uses the public Ox Content 3.1.1 release. Native custom-host stylesheet
+The site uses the public Ox Content 3.1.2 release. Native custom-host stylesheet
 discovery replaces the last local Vite plugin; no implementation or ambient
 declaration remains under `src/ox-content`.
 
@@ -114,37 +114,43 @@ generated files are byte-for-byte identical to the pre-audit build. Remaining
 adapters are site composition, not reproduced framework machinery; this audit
 did not uncover a new upstream public-contract gap requiring an issue.
 
-## Pending: island discovery embed rendering
+## Adopted in 3.1.2
 
-[#1370](https://github.com/ubugeeei-prod/ox-content/issues/1370) tracks full embed
-rendering during Solid client-island discovery. The registry alone overrides
-`embeds: false`; the custom host retains the shared embed settings for page output.
+- [#1370](https://github.com/ubugeeei-prod/ox-content/issues/1370), fixed by
+  [#1373](https://github.com/ubugeeei-prod/ox-content/pull/1373): island discovery
+  disables embeds internally. Removed the registry-only `embeds: false` override;
+  actual page rendering retains the shared embed settings.
+- [#1371](https://github.com/ubugeeei-prod/ox-content/issues/1371), fixed by
+  [#1372](https://github.com/ubugeeei-prod/ox-content/pull/1372): custom-host output
+  shares a per-build cache for identical inline JS/CSS minification. HTML
+  compression remains enabled, including hydration-comment preservation.
 
-On 2026-09-08, Vite's reported client build fell from 10.75 s initially
-(1.47 s on a later warm run) to 692 ms / 674 ms with the override. These timings
-exclude the full CLI/SSG wall time. The generated output trees were byte-identical;
-428 custom-host outputs and the same client island were preserved. A build before
-the page-component rename also took 10.61 s with the same dependencies.
+Verification on 2026-09-09: check and all 38 tests in 12 files passed. All generated
+files were byte-identical to the pre-update 3.1.1 build, with 428 custom-host
+outputs. Browser verification covered production GtvChart rendering and arrow-key
+selection, article link previews, and Tweet text/images on a fresh dev server.
+A source audit found no reproduced regression in the changed discovery/cache
+paths; CSS cache keys distinguish context and JS keys distinguish inline scripts.
 
-Adopt an official upstream release when discovery no longer needs this override,
-remove it, and recheck build timing, generated output and client island behaviour.
-Issue closure alone is not proof that the fix has shipped.
+| Measurement | 3.1.2 |
+| --- | --- |
+| First build after dependency update, CLI wall | 3.97 s |
+| Subsequent warm build, CLI wall | 3.91 s |
+| Empty Vite cache, CLI wall | 4.08 s |
+| Vite-reported client build | 0.64-0.67 s |
+| Profiled HTML minification and writes | 0.24 s |
+| Profiled coordinated output writer | 0.57 s |
 
-## Pending: custom-host output performance
+The Vite-cache-cold run retained the existing Ox Content embed cache; it is not
+a fully network-cold build. The previous 3.1.1 diagnostic samples measured
+minification/writes at 0.57 s, output writer at 0.97 s and CLI wall at 4.90 s.
+The immediate pre-update CLI sample was 7.58 s, illustrating run-to-run variance.
+These are diagnostic samples, not controlled benchmark guarantees.
 
-[#1371](https://github.com/ubugeeei-prod/ox-content/issues/1371) tracks production
-HTML minification performance. Warm diagnostic runs on 2026-09-08 measured route
-preparation at 1.42-1.56 s (blog rendering about 1.25 s), page rendering at
-0.17-0.25 s, output planning at 0.16 s and loader shutdown at 0.25-0.37 s.
-HTML minification plus writes took 0.57 s. Temporarily disabling only host HTML
-minification reduced coordinated output writing from 0.97 s to 0.39 s and CLI
-wall time from 4.90 s to 4.12 s. These are diagnostic samples, not a controlled
-benchmark; production minification remains enabled.
-
-Monitor and adopt supported upstream improvements while retaining HTML,
-hydration, inline CSS/JS and compression semantics. Measure total CLI/SSG time
-as well as Vite's client timing; do not equate client completion with full build
-completion.
+Continue monitoring and repeating release/adopt/remove/verify/re-audit within
+build performance and the related island/embed scope. Both initial issues are
+released and adopted; this checkpoint does not stop the monitor or authorise
+marking the Draft PR ready or merging it.
 
 ## Remaining boundary
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,17 +25,17 @@ catalogs:
       specifier: ^2.2.510
       version: 2.2.520
     '@ox-content/islands':
-      specifier: 3.1.1
-      version: 3.1.1
+      specifier: 3.1.2
+      version: 3.1.2
     '@ox-content/theme-color-kanagawa':
-      specifier: 3.1.1
-      version: 3.1.1
+      specifier: 3.1.2
+      version: 3.1.2
     '@ox-content/vite-plugin':
-      specifier: 3.1.1
-      version: 3.1.1
+      specifier: 3.1.2
+      version: 3.1.2
     '@ox-content/vite-plugin-solid':
-      specifier: 3.1.1
-      version: 3.1.1
+      specifier: 3.1.2
+      version: 3.1.2
     '@solidjs/vite-plugin':
       specifier: ^3.0.0-next.36
       version: 3.0.0-next.36
@@ -139,16 +139,16 @@ importers:
         version: 2.2.520
       '@ox-content/islands':
         specifier: 'catalog:'
-        version: 3.1.1
+        version: 3.1.2
       '@ox-content/theme-color-kanagawa':
         specifier: 'catalog:'
-        version: 3.1.1(@ox-content/vite-plugin@3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3))
+        version: 3.1.2(@ox-content/vite-plugin@3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3))
       '@ox-content/vite-plugin':
         specifier: 'catalog:'
-        version: 3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)
+        version: 3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)
       '@ox-content/vite-plugin-solid':
         specifier: 'catalog:'
-        version: 3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@solidjs/vite-plugin@3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4))(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@2.0.0-rc.4)(svelte@5.56.10)(tailwindcss@4.3.3)
+        version: 3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@solidjs/vite-plugin@3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4))(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@2.0.0-rc.4)(svelte@5.56.10)(tailwindcss@4.3.3)
       '@solidjs/vite-plugin':
         specifier: 'catalog:'
         version: 3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4)
@@ -898,69 +898,69 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ox-content/binding-darwin-arm64@3.1.1':
-    resolution: {integrity: sha512-L0sTOWYMxraHM+/kRq7MQdL9fMJUWmbu95noNiEnvb39+VfCmey6kYR2PSi9LqEfMl4uCKN36trbbXXBG5Q5/A==}
+  '@ox-content/binding-darwin-arm64@3.1.2':
+    resolution: {integrity: sha512-MXgs1BCKlqZqA5vP5yIy37x+2oQ2HRvTjfatVZapUf/urSDYgkVF27IwNSwnGxlWi5GTbvPvkhBG1e+/hzYJMA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ox-content/binding-darwin-x64@3.1.1':
-    resolution: {integrity: sha512-lxrNynouzR72FiN3JsTk+44NdrsMiHz9UMhCCy5MrLneJrTchQhLh3DEwWuFbe6P9YawFzWg5ynTMGPxrT9TpQ==}
+  '@ox-content/binding-darwin-x64@3.1.2':
+    resolution: {integrity: sha512-9AMEXSRwMLmxfhvMkVWt2EGI4q1yfDxsf021BhiXFIhGsq3jO/j6eiqr8OM9hhaZTGd3o1QXDHYOFsHdf4StDA==}
     cpu: [x64]
     os: [darwin]
 
-  '@ox-content/binding-linux-arm64-gnu@3.1.1':
-    resolution: {integrity: sha512-31HAiPMVZBCmKUAWEd9TyOrXTJR6Hoivozx9Z9lTBdRb27X1lOCx2cWNf5qhvXWc2ZUk+4eW+ApqpQjxS+DXeQ==}
+  '@ox-content/binding-linux-arm64-gnu@3.1.2':
+    resolution: {integrity: sha512-HVouAE+otCdrzkrDG2TYmg4cDM3IeGhyTGqRLQ+PVglnIRAf7kvraTzlvJ7jn/j/pLIs1lYt/cjxxYhuzlsUaA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ox-content/binding-linux-arm64-musl@3.1.1':
-    resolution: {integrity: sha512-vZrMDYQ/T+kqDVJ/Crc+fi1ESiNwSte6hLSb58BbGnO8o5RaIaT06jk9wSb065Z+FFp4JT3W2+jNe2IdDQ22aw==}
+  '@ox-content/binding-linux-arm64-musl@3.1.2':
+    resolution: {integrity: sha512-MB7eHtfAwk6y5ZukeABSL/HhnEoMu0a3q4IjX1NizhyOn1/KWoP/vRIxhHU6lNnOD6J4pYjH9q2PWecknx1uww==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@ox-content/binding-linux-x64-gnu@3.1.1':
-    resolution: {integrity: sha512-hKuNTtGjWjYVIBkimalo0Qtu70Nq0ZKFA2qAiKLpR0TQjjSy6tjzi+H0WVZtctXOU3SBpHNTeK9x5jxe4LqOtQ==}
+  '@ox-content/binding-linux-x64-gnu@3.1.2':
+    resolution: {integrity: sha512-P8WO9rWz2aRxjlDfcE/0w6Vg9ldiJCWZxztusJdkTyOdwpb0rc16sithQu+JaUCiVItxDPUbd16d5ylJtmyBYA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ox-content/binding-linux-x64-musl@3.1.1':
-    resolution: {integrity: sha512-Wgr00cRgkiGKTeW8/8EI6KGyG3RWP2BTA2XnQZIG+MjjOqeyUrxXfdJhwNt5Cpdf5+4PXyCJHMVS76rVE8/THg==}
+  '@ox-content/binding-linux-x64-musl@3.1.2':
+    resolution: {integrity: sha512-gRK8oKJt5fdNBdfmvophIOZsDYqUJvP7PaKQkGTymgW3Asg4M9kFP6DGbGmRVlTfHkCIlNQTRjFmHw78sPaSUg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@ox-content/binding-win32-x64-msvc@3.1.1':
-    resolution: {integrity: sha512-dsbxKcS19p/O7JlOeijpJtinBjswXWkyclcA75eY37MrvYU8QXmIcGXKcArJ1VGAQM4vZv/RQd25VJaEyspJxQ==}
+  '@ox-content/binding-win32-x64-msvc@3.1.2':
+    resolution: {integrity: sha512-2rkeA/KO1xO3rsC9QruuggZvJd8WOsIgMDOS+eTf1TgHDpcHXmaN4v7je0uyr/4jGwpPupDZW+EXSugX9AezEQ==}
     cpu: [x64]
     os: [win32]
 
-  '@ox-content/islands@3.1.1':
-    resolution: {integrity: sha512-nfXeQ2+GtOBSoXO7gMIyexh1QgxAqU1anuwfGKp+bwf2luqhFaHD22k7FG3Ttb8wAFjnz7wb4EcChG4V6/U2jQ==}
+  '@ox-content/islands@3.1.2':
+    resolution: {integrity: sha512-Q+tVkLGeh2Em+SnmDSQltwY1UtPrdA75hTMwYVBJWKBveDsVc/l0e3WlhsIzYUPgbbRY5TeKh/h7w7nKTR5+VQ==}
 
-  '@ox-content/napi@3.1.1':
-    resolution: {integrity: sha512-Q8ua9jCOp+AKqHG/53+VRLsBl2gApt5O2owYb44Ii1FbUfKlqoz5foQlnM9Iym0uG3qh+OAqHtbeAobI/kO4RQ==}
+  '@ox-content/napi@3.1.2':
+    resolution: {integrity: sha512-tbnzKHTxBEVEVdOl9DGTOy+5W603oP4Y6yGVa+mlk4VyaOUZMvNDe+ImMSDianSQwHEf8Li1iXiGcYjgvKBrAw==}
 
-  '@ox-content/theme-color-kanagawa@3.1.1':
-    resolution: {integrity: sha512-wigRWZBqPeQdDSEp+6wgEYSch9w39uDO14sdy/PmGZyKChxqV5pmTdZmu6PYOY06v6czsd8Ve7/aVgrlC/lfOw==}
+  '@ox-content/theme-color-kanagawa@3.1.2':
+    resolution: {integrity: sha512-fKylihTa3d5GApQL1cCl7nmotCkMyaM/TGpF69WvI4zO/sjvRn1dtZ4wXgWEEVENgczDnLnNiWVuIuYCNAAKsA==}
     peerDependencies:
       '@ox-content/vite-plugin': '>=3.0.0-alpha.1'
     peerDependenciesMeta:
       '@ox-content/vite-plugin':
         optional: true
 
-  '@ox-content/vite-plugin-solid@3.1.1':
-    resolution: {integrity: sha512-Ocflof7SuNPFW+xc8AMtn77u5ftuutwxWHldm8lhC0KNG0ZG6yUEYdZiPM7Efe5VRmkP8G5m5V2Tsw5ZaoBqbg==}
+  '@ox-content/vite-plugin-solid@3.1.2':
+    resolution: {integrity: sha512-Lgl0XBkG8MtOhTlP/8oFr59nfPfmRUqktZwxY22vrzFa5ty4+qlLNtkKK13leHEpTl0nMSECGoySpeG0kUOSyQ==}
     peerDependencies:
       '@solidjs/vite-plugin': ^3.0.0-next.36
       '@solidjs/web': ^2.0.0-rc.4
       solid-js: ^2.0.0-rc.4
       vite: ^8.0.0 || ^9.0.0
 
-  '@ox-content/vite-plugin@3.1.1':
-    resolution: {integrity: sha512-r2hWW2wly2R3UMkDnlwcgAabAkb/HuISkaJ8cKaKaAmuEqUTzNBdFM9jpNaTnxD7FOczZ9+NE7urRpBlV4N0KA==}
+  '@ox-content/vite-plugin@3.1.2':
+    resolution: {integrity: sha512-HKu3Mn5TLOhixE0QXeWPmxzmbYfhh3JKpOocSjd8aHjdLQSytSVSLE/zPtnoezAlrzqjk11YzaTQqdpStsfmCQ==}
     hasBin: true
     peerDependencies:
       '@vue/compiler-sfc': ^3.4.0
@@ -4921,47 +4921,47 @@ snapshots:
   '@oven/bun-windows-x64@1.4.2':
     optional: true
 
-  '@ox-content/binding-darwin-arm64@3.1.1':
+  '@ox-content/binding-darwin-arm64@3.1.2':
     optional: true
 
-  '@ox-content/binding-darwin-x64@3.1.1':
+  '@ox-content/binding-darwin-x64@3.1.2':
     optional: true
 
-  '@ox-content/binding-linux-arm64-gnu@3.1.1':
+  '@ox-content/binding-linux-arm64-gnu@3.1.2':
     optional: true
 
-  '@ox-content/binding-linux-arm64-musl@3.1.1':
+  '@ox-content/binding-linux-arm64-musl@3.1.2':
     optional: true
 
-  '@ox-content/binding-linux-x64-gnu@3.1.1':
+  '@ox-content/binding-linux-x64-gnu@3.1.2':
     optional: true
 
-  '@ox-content/binding-linux-x64-musl@3.1.1':
+  '@ox-content/binding-linux-x64-musl@3.1.2':
     optional: true
 
-  '@ox-content/binding-win32-x64-msvc@3.1.1':
+  '@ox-content/binding-win32-x64-msvc@3.1.2':
     optional: true
 
-  '@ox-content/islands@3.1.1': {}
+  '@ox-content/islands@3.1.2': {}
 
-  '@ox-content/napi@3.1.1':
+  '@ox-content/napi@3.1.2':
     optionalDependencies:
-      '@ox-content/binding-darwin-arm64': 3.1.1
-      '@ox-content/binding-darwin-x64': 3.1.1
-      '@ox-content/binding-linux-arm64-gnu': 3.1.1
-      '@ox-content/binding-linux-arm64-musl': 3.1.1
-      '@ox-content/binding-linux-x64-gnu': 3.1.1
-      '@ox-content/binding-linux-x64-musl': 3.1.1
-      '@ox-content/binding-win32-x64-msvc': 3.1.1
+      '@ox-content/binding-darwin-arm64': 3.1.2
+      '@ox-content/binding-darwin-x64': 3.1.2
+      '@ox-content/binding-linux-arm64-gnu': 3.1.2
+      '@ox-content/binding-linux-arm64-musl': 3.1.2
+      '@ox-content/binding-linux-x64-gnu': 3.1.2
+      '@ox-content/binding-linux-x64-musl': 3.1.2
+      '@ox-content/binding-win32-x64-msvc': 3.1.2
 
-  '@ox-content/theme-color-kanagawa@3.1.1(@ox-content/vite-plugin@3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3))':
+  '@ox-content/theme-color-kanagawa@3.1.2(@ox-content/vite-plugin@3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3))':
     optionalDependencies:
-      '@ox-content/vite-plugin': 3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)
+      '@ox-content/vite-plugin': 3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)
 
-  '@ox-content/vite-plugin-solid@3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@solidjs/vite-plugin@3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4))(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@2.0.0-rc.4)(svelte@5.56.10)(tailwindcss@4.3.3)':
+  '@ox-content/vite-plugin-solid@3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@solidjs/vite-plugin@3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4))(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@2.0.0-rc.4)(svelte@5.56.10)(tailwindcss@4.3.3)':
     dependencies:
-      '@ox-content/islands': 3.1.1
-      '@ox-content/vite-plugin': 3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)
+      '@ox-content/islands': 3.1.2
+      '@ox-content/vite-plugin': 3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)
       '@solidjs/vite-plugin': 3.0.0-next.36(@solidjs/web@2.0.0-rc.4(solid-js@2.0.0-rc.4))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(solid-js@2.0.0-rc.4)
       '@solidjs/web': 2.0.0-rc.4(solid-js@2.0.0-rc.4)
       solid-js: 2.0.0-rc.4
@@ -4984,14 +4984,14 @@ snapshots:
       - vue
       - yauzl
 
-  '@ox-content/vite-plugin@3.1.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)':
+  '@ox-content/vite-plugin@3.1.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@7.0.2)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.10)(tailwindcss@4.3.3)':
     dependencies:
       '@cspell/dict-de-de': 4.1.2
       '@cspell/dict-en_us': 4.4.37
       '@cspell/dict-fr-fr': 2.3.2
       '@cspell/dict-pl_pl': 3.0.6
       '@mermaid-js/mermaid-cli': 11.17.0(@babel/core@7.29.7)(@babel/template@7.29.7)(puppeteer@25.10.0)(tailwindcss@4.3.3)
-      '@ox-content/napi': 3.1.1
+      '@ox-content/napi': 3.1.2
       '@resvg/resvg-js': 2.6.2
       clean-css: 5.3.3
       cspell-lib: 10.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,11 +7,11 @@ catalog:
   '@fontsource/jetbrains-mono': ^5.3.0
   '@fontsource/roboto-condensed': ^5.3.0
   '@iconify/json': ^2.2.510
-  '@ox-content/islands': 3.1.1
-  '@ox-content/napi': 3.1.1
-  '@ox-content/theme-color-kanagawa': 3.1.1
-  '@ox-content/vite-plugin': 3.1.1
-  '@ox-content/vite-plugin-solid': 3.1.1
+  '@ox-content/islands': 3.1.2
+  '@ox-content/napi': 3.1.2
+  '@ox-content/theme-color-kanagawa': 3.1.2
+  '@ox-content/vite-plugin': 3.1.2
+  '@ox-content/vite-plugin-solid': 3.1.2
   '@solidjs/vite-plugin': ^3.0.0-next.36
   '@solidjs/web': ^2.0.0-rc.4
   '@tanstack/charts': 0.14.0

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,7 @@ export default defineConfig(({ command, mode }) => {
 		},
 		plugins: [
 			createSolidHtmlHostIslandRegistry({
-				oxContent: { ...OX_CONTENT_BUILD_OPTIONS, embeds: false },
+				oxContent: OX_CONTENT_BUILD_OPTIONS,
 				collectionDocuments: BLOG_ISLAND_DOCUMENTS,
 			}).plugin,
 			solid({ compiler: 'native', ssr: command === 'serve', solid: { hydratable: false } }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,6 @@ export default defineConfig(({ command, mode }) => {
 		},
 		plugins: [
 			createSolidHtmlHostIslandRegistry({
-				// Island discovery needs component bindings, not remote embed rendering.
 				oxContent: { ...OX_CONTENT_BUILD_OPTIONS, embeds: false },
 				collectionDocuments: BLOG_ISLAND_DOCUMENTS,
 			}).plugin,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,8 @@ export default defineConfig(({ command, mode }) => {
 		},
 		plugins: [
 			createSolidHtmlHostIslandRegistry({
-				oxContent: OX_CONTENT_BUILD_OPTIONS,
+				// Island discovery needs component bindings, not remote embed rendering.
+				oxContent: { ...OX_CONTENT_BUILD_OPTIONS, embeds: false },
 				collectionDocuments: BLOG_ISLAND_DOCUMENTS,
 			}).plugin,
 			solid({ compiler: 'native', ssr: command === 'serve', solid: { hydratable: false } }),


### PR DESCRIPTION
Adopt Ox Content 3.1.2's upstream build optimisations: island discovery now suppresses embed rendering internally, and the HTML writer reuses identical inline JS/CSS minification results. Remove the temporary registry override while keeping production page embeds and HTML compression enabled.

Fixes adopted: https://github.com/ubugeeei-prod/ox-content/pull/1373 (#1370) and https://github.com/ubugeeei-prod/ox-content/pull/1372 (#1371). All five Ox Content catalogue entries are aligned to 3.1.2.

Validation: pnpm check, 38 tests in 12 files, 428 custom-host outputs, and byte-identical complete output trees compared with 3.1.1. Browser checks cover GtvChart drawing/arrow-key selection, article link previews, and Tweet text/images on a fresh dev server. A focused source audit found no regression in discovery scope, minifier cache context keys, or hydration-comment preservation.

Timing samples: CLI 3.97 s after update, 3.91 s warm, 4.08 s with an empty Vite cache (embed cache retained); Vite client 0.64–0.67 s. Profiled minification/writes fell from the previous diagnostic 0.57 s to 0.24 s; coordinated output writer 0.97 s to 0.57 s. These are diagnostic samples, not controlled benchmark guarantees.

Keep this PR in draft. The hourly monitor continues the release/adopt/remove/verify/re-audit cycle after both initial issues are resolved. No authored article changes or Solid version updates are included. Details: docs/ox-content.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Ox Content 3.1.2, which fixes the island-discovery embed rendering and custom-host minification issues, removing the local override and updating tracking docs.

**Dependencies**
- Upgrades `@ox-content` packages to 3.1.2 across the workspace catalog and lockfile.
- Removes the registry-only `embeds: false` override; 3.1.2 disables embeds internally during island discovery.
- Documents adoption of upstream fixes for #1370 and #1371 in `docs/ox-content.md`.

Verification confirms byte-identical output to the pre-update 3.1.1 build, with improved build times.

<sup>Written for commit ca751d2078fe211e5ac87d68a60624b87df15ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

