### PR TITLE
chore(mcp): remove unused Svelte server configuration

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,0 @@
-experimental_use_rmcp_client = true
-
-[mcp_servers.svelte]
-url = "https://mcp.svelte.dev/mcp"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-	"mcpServers": {
-		"svelte": {
-			"type": "http",
-			"url": "https://mcp.svelte.dev/mcp"
-		}
-	}
-}


### PR DESCRIPTION
Remove the obsolete Svelte MCP registration from both project-level Codex and generic MCP configuration.

The current site uses Solid/Vite, so Svelte references in the lockfile are optional peer resolutions from shared tooling and remain unchanged.

Testing:
- pnpm check
- pnpm exec vp test --run (12 files, 38 tests)
- pnpm build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused Svelte MCP server registration from `.codex/config.toml` and `.mcp.json` since the site runs on Solid/Vite. Svelte references in the lockfile are optional peer resolutions from shared tooling and stay as-is.

<sup>Written for commit af50cc4c6028d1163c1757a7cacb126270a72260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the Svelte MCP server configuration.
  - Removed the experimental MCP client setting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->