### PR TITLE
chore(renovate): gate automerges on CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,11 @@
 	"nix": {
 		"enabled": true
 	},
-	"extends": ["github>ryoppippi/renovate-config"]
+	"extends": ["github>ryoppippi/renovate-config"],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"automerge": true
+	},
+	"automerge": true,
+	"platformAutomerge": false
 }


### PR DESCRIPTION
## Summary

- Keep Nix lock-file maintenance enabled explicitly and allow its updates to be automerged.

- Make Renovate automerge behaviour explicit and route merges through Renovate instead of GitHub platform-native automerge.
## Why

GitHub auto-merge is enabled, but main has no required status checks. Disabling platform-native automerge lets Renovate wait for the repository checks before merging its update PRs, while the Nix manager continues to update flake inputs and flake.lock.

## Testing
- jq empty .github/renovate.json

- git diff --check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Renovate config so automerges wait for CI checks before merging. Disables GitHub platform-native automerge and keeps Nix lock-file maintenance enabled and automerged.

**Testing**
- Verified with `jq empty .github/renovate.json` and `git diff --check`.

<sup>Written for commit 0af0ae13e7efef2971d6f205d165ee5ce56ee91a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency maintenance settings to streamline routine lockfile updates.
  - No user-facing features or behavior changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->