### PR TITLE
refactor(svelte): simplify markup and adopt declaration tags

### DIFF
--- a/src/components/SiteLayout/NavigationActions.svelte
+++ b/src/components/SiteLayout/NavigationActions.svelte
@@ -1,28 +1,25 @@
 <div data-nosnippet class="siteNavigationActions">
-	<a class="siteCvLink" href="/cv" rel="noopener noreferrer" target="_blank"
-		><span class="siteCvLabel"
-			>cv{' '}<span class={`icon-[line-md--download-outline] siteCvIcon`} aria-hidden="true"
-			></span></span
-		></a
-	>
+	<a class="siteCvLink" href="/cv" rel="noopener noreferrer" target="_blank">
+		<span class="siteCvLabel">
+			cv <span class={['icon-[line-md--download-outline]', 'siteCvIcon']} aria-hidden="true"></span>
+		</span>
+	</a>
 	<div class="siteTools">
-		<span class="siteThemeControl" data-dark-mode></span><a
-			class="siteToolLink"
-			aria-label="RSS feed"
-			href="/feed.xml"
-			><span class="icon-[line-md--rss]" aria-hidden="true"></span><span class="visuallyHidden"
-				>RSS feed</span
-			></a
-		><a
+		<span class="siteThemeControl" data-dark-mode></span>
+		<a class="siteToolLink" aria-label="RSS feed" href="/feed.xml">
+			<span class="icon-[line-md--rss]" aria-hidden="true"></span>
+			<span class="visuallyHidden">RSS feed</span>
+		</a>
+		<a
 			class="siteToolLink"
 			aria-label="Source code on GitHub"
 			href="https://github.com/ryoppippi/ryoppippi.com"
 			rel="noopener noreferrer"
 			target="_blank"
-			><span class="icon-[teenyicons--github-solid]" aria-hidden="true"></span><span
-				class="visuallyHidden">Source code</span
-			></a
 		>
+			<span class="icon-[teenyicons--github-solid]" aria-hidden="true"></span>
+			<span class="visuallyHidden">Source code</span>
+		</a>
 	</div>
 </div>
 

--- a/src/components/SiteLayout/NavigationLinks.svelte
+++ b/src/components/SiteLayout/NavigationLinks.svelte
@@ -17,12 +17,13 @@
 
 <div data-nosnippet class="siteNavigationLinks">
 	{#each navigationLinks as link}
-		{@const active = pathname.startsWith('activePrefix' in link ? link.activePrefix : link.href)}
-		<a class="siteNavigationLink" aria-current={active ? 'page' : undefined} href={link.href}
-			><span>{link.label}</span><span
-				class={`siteNavigationMarker${active ? ` siteNavigationMarkerActive` : ''}`}
-			></span></a
-		>
+		{const active = $derived(
+			pathname.startsWith('activePrefix' in link ? link.activePrefix : link.href),
+		)}
+		<a class="siteNavigationLink" aria-current={active ? 'page' : undefined} href={link.href}>
+			<span>{link.label}</span>
+			<span class={['siteNavigationMarker', active && 'siteNavigationMarkerActive']}></span>
+		</a>
 	{/each}
 </div>
 

--- a/src/components/SiteLayout/SiteHeader.svelte
+++ b/src/components/SiteLayout/SiteHeader.svelte
@@ -9,13 +9,16 @@
 </script>
 
 <header class="siteHeader">
-	<div data-nosnippet class={`siteBrandSlot${isHome ? ` siteBrandSlotHome` : ''}`}>
-		{#if !isHome}<a class="siteBrand" aria-label="Home" href="/"
-				><span style="view-transition-name:title-ryoppippi">@ryoppippi</span></a
-			>{/if}
+	<div data-nosnippet class={['siteBrandSlot', isHome && 'siteBrandSlotHome']}>
+		{#if !isHome}
+			<a class="siteBrand" aria-label="Home" href="/">
+				<span style="view-transition-name:title-ryoppippi">@ryoppippi</span>
+			</a>
+		{/if}
 	</div>
 	<nav class="siteNavigation" aria-label="Primary navigation">
-		<NavigationLinks {pathname}></NavigationLinks><NavigationActions></NavigationActions>
+		<NavigationLinks {pathname}></NavigationLinks>
+		<NavigationActions></NavigationActions>
 	</nav>
 </header>
 

--- a/src/components/SiteLayout/index.svelte
+++ b/src/components/SiteLayout/index.svelte
@@ -9,7 +9,9 @@
 	let { content, pathname }: SiteLayoutProps = $props();
 </script>
 
-<span data-nosnippet><a class="skipLink" href="#main-content">Skip to content</a></span>
+<span data-nosnippet>
+	<a class="skipLink" href="#main-content">Skip to content</a>
+</span>
 <div class="siteLayout">
 	<SiteHeader {pathname}></SiteHeader>
 	<main id="main-content" tabindex="-1">{@html content}</main>

--- a/src/components/WorksNav/index.svelte
+++ b/src/components/WorksNav/index.svelte
@@ -19,19 +19,25 @@
 <div class="worksNavigationHeader">
 	<h1 class="worksTitle">Works</h1>
 	<p class="worksTagline">
-		<span class="worksNowrap">... that</span> <span class="worksNowrap">I</span>{' '}<span
-			class="worksNowrap">(&rsquo;m working | &rsquo;ve worked)</span
-		>{' '}<span class="worksNowrap">on</span>
+		<span class="worksNowrap">... that</span>
+		<span class="worksNowrap">I</span>
+		<span class="worksNowrap">(&rsquo;m working | &rsquo;ve worked)</span>
+		<span class="worksNowrap">on</span>
 	</p>
 	<nav class="worksSections" aria-label="Works sections">
 		{#each sections as item}
 			<a
-				class={`worksSectionLink${item === active ? ` worksSectionLinkActive` : ''}`}
+				class={['worksSectionLink', item === active && 'worksSectionLinkActive']}
 				aria-current={item === active ? 'page' : undefined}
 				href={`/works/${item}/`}
 				style={`view-transition-name:works-nav-${item}`}
-				>{#if item === 'oss'}{'OSS'}{:else}{item[0].toUpperCase() + item.slice(1)}{/if}</a
 			>
+				{#if item === 'oss'}
+					OSS
+				{:else}
+					{item[0].toUpperCase() + item.slice(1)}
+				{/if}
+			</a>
 		{/each}
 	</nav>
 </div>

--- a/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/EvidenceTable.svelte
+++ b/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/EvidenceTable.svelte
@@ -52,9 +52,9 @@
 		</thead>
 		<tbody>
 			{#each rows as row, index}
-				{@const localised = localisePoint(row, lang)}
+				{const localised = $derived(localisePoint(row, lang))}
 				<tr
-					class:focused={focused === index}
+					class={[focused === index && 'focused']}
 					data-testid="gtv-row"
 					onfocusin={() => onFocusedChange(index)}
 					onfocusout={() => onFocusedChange(null)}
@@ -64,9 +64,9 @@
 					<th scope="row">
 						{localised.label}{copy.headingOpen}
 						{#if localised.milestoneHref}
-							<a href={localised.milestoneHref} rel="noopener noreferrer" target="_blank"
-								>{localised.milestone}</a
-							>
+							<a href={localised.milestoneHref} rel="noopener noreferrer" target="_blank">
+								{localised.milestone}
+							</a>
 						{:else}
 							{localised.milestone}
 						{/if}
@@ -84,8 +84,10 @@
 								<a
 									href={part.href}
 									rel={part.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-									target={part.href.startsWith('http') ? '_blank' : undefined}>{part.text}</a
+									target={part.href.startsWith('http') ? '_blank' : undefined}
 								>
+									{part.text}
+								</a>
 							{/if}
 						{/each}
 					</td>

--- a/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/GtvChart.svelte
+++ b/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/GtvChart.svelte
@@ -25,7 +25,7 @@
 <figure class="gtv-chart" data-testid="gtv-chart" bind:this={figure}>
 	<Legend {lang} />
 	<p aria-atomic="true" aria-live="polite" class="readout">{readout || '\u00a0'}</p>
-	<div class="wipe" class:revealed={scrollReveal.revealed}>
+	<div class={['wipe', scrollReveal.revealed && 'revealed']}>
 		<Timeline {focused} {lang} onFocusedChange={(value) => (focused = value)} />
 	</div>
 	<EvidenceTable {focused} {lang} onFocusedChange={(value) => (focused = value)} />

--- a/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/Legend.svelte
+++ b/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/Legend.svelte
@@ -4,12 +4,20 @@
 
 	let { lang }: { lang?: ChartLang } = $props();
 	const copy = $derived(uiCopy[resolveChartLang(lang)].legend);
+	const items = [
+		'mid',
+		'high',
+		'low',
+		'stars',
+		'after',
+	] as const satisfies readonly (keyof typeof copy)[];
 </script>
 
 <ul class="legend">
-	<li><span aria-hidden="true" class="swatch swatch--mid"></span>{copy.mid}</li>
-	<li><span aria-hidden="true" class="swatch swatch--high"></span>{copy.high}</li>
-	<li><span aria-hidden="true" class="swatch swatch--low"></span>{copy.low}</li>
-	<li><span aria-hidden="true" class="swatch swatch--stars"></span>{copy.stars}</li>
-	<li><span aria-hidden="true" class="swatch swatch--after"></span>{copy.after}</li>
+	{#each items as item}
+		<li>
+			<span aria-hidden="true" class={['swatch', `swatch--${item}`]}></span>
+			{copy[item]}
+		</li>
+	{/each}
 </ul>

--- a/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/Timeline.svelte
+++ b/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/Timeline.svelte
@@ -49,7 +49,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div onpointerleave={() => onFocusedChange(null)}>
 	<div
-		class="ts-chart-host canvas"
+		class={['ts-chart-host', 'canvas']}
 		style:position="relative"
 		style:width="100%"
 		style:aspect-ratio={ASPECT_RATIO}

--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -19,7 +19,8 @@
 	</div>
 	<div class="homeHeading">
 		<h1 class="homeTitle" style="view-transition-name:title-ryoppippi">
-			<span class="homeHandle">@ryoppippi</span>{' '}<span class="homeRole">Engineer</span>
+			<span class="homeHandle">@ryoppippi</span>
+			<span class="homeRole">Engineer</span>
 		</h1>
 	</div>
 </article>
@@ -31,8 +32,10 @@
 					aria-label={label}
 					href={`${SITE_ORIGIN}${href}`}
 					rel="noopener noreferrer"
-					target="_blank"><span class={`${icon} homeSocialIcon`} aria-hidden="true"></span></a
+					target="_blank"
 				>
+					<span class={[icon, 'homeSocialIcon']} aria-hidden="true"></span>
+				</a>
 			</div>
 		{/each}
 	</article>

--- a/src/pages/about/About.svelte
+++ b/src/pages/about/About.svelte
@@ -20,7 +20,9 @@
 		<div class="cardRule" aria-hidden="true"></div>
 		<div class="cardContent">
 			<div class="visuals">
-				<figure class="portrait"><ProfileImage class="profileImage"></ProfileImage></figure>
+				<figure class="portrait">
+					<ProfileImage class="profileImage"></ProfileImage>
+				</figure>
 				<figure class="mascot">
 					<img
 						class="mascotImage"
@@ -36,30 +38,37 @@
 			</div>
 			<div class="copy">
 				<h1 class="heading">ryoppippi</h1>
-				<p class="kicker"><em>... coder without ai</em></p>
+				<p class="kicker">
+					<em>... coder without ai</em>
+				</p>
 				<p class="description">
-					<strong class="name">{SITE_OWNER.handle.slice(1)}</strong>{' '}<span class="alias"
-						>({SITE_OWNER.name} / <span lang="ja">{SITE_OWNER.japaneseName}</span>)</span
-					>{' '}builds coding agents, developer tools, and human-centred AI products. Maintains{' '}<a
+					<strong class="name">{SITE_OWNER.handle.slice(1)}</strong>
+					<span class="alias">
+						({SITE_OWNER.name} / <span lang="ja">{SITE_OWNER.japaneseName}</span>)
+					</span>
+					builds coding agents, developer tools, and human-centred AI products. Maintains
+					<a
 						class="inlineLink"
 						href="https://ccusage.com/gh"
 						rel="noopener noreferrer"
-						target="_blank">ccusage</a
-					>{' '}and{' '}<a class="inlineLink" href="/works/oss/">multiple OSS projects</a>.
+						target="_blank"
+					>
+						ccusage
+					</a>
+					and <a class="inlineLink" href="/works/oss/">multiple OSS projects</a>.
 					<span class="role">Founding Engineer</span>
-					at{' '}<a
-						class="inlineLink"
-						href="https://rork.com/"
-						rel="noopener noreferrer"
-						target="_blank">Rork</a
-					>.
+					at
+					<a class="inlineLink" href="https://rork.com/" rel="noopener noreferrer" target="_blank">
+						Rork
+					</a>.
 				</p>
 				<ul class="links">
 					{#each links as [label, href]}
 						<li class="linkItem">
-							<a class="link" {href} rel="noopener noreferrer" target="_blank"
-								><span>{label}</span><span class="linkArrow" aria-hidden="true">↗</span></a
-							>
+							<a class="link" {href} rel="noopener noreferrer" target="_blank">
+								<span>{label}</span>
+								<span class="linkArrow" aria-hidden="true">↗</span>
+							</a>
 						</li>
 					{/each}
 				</ul>

--- a/src/pages/blog/BlogList.svelte
+++ b/src/pages/blog/BlogList.svelte
@@ -24,19 +24,22 @@
 
 <h1 class="visuallyHidden">Blog</h1>
 <div class="blogFilters">
-	<button class="blogFilter" aria-pressed="false" data-filter="english" type="button"
-		><span class="icon-[carbon--checkbox]" aria-hidden="true"></span>English Only</button
-	><button class="blogFilter" aria-pressed="false" data-filter="local" type="button"
-		><span class="icon-[carbon--checkbox]" aria-hidden="true"></span>ryoppippi.com exclusive</button
-	>
+	<button class="blogFilter" aria-pressed="false" data-filter="english" type="button">
+		<span class="icon-[carbon--checkbox]" aria-hidden="true"></span>
+		English Only
+	</button>
+	<button class="blogFilter" aria-pressed="false" data-filter="local" type="button">
+		<span class="icon-[carbon--checkbox]" aria-hidden="true"></span>
+		ryoppippi.com exclusive
+	</button>
 </div>
-<span class="visuallyHidden" id="blog-filter-status" aria-atomic="true" aria-live="polite"
-	>Showing all blog posts</span
->
+<span class="visuallyHidden" id="blog-filter-status" aria-atomic="true" aria-live="polite">
+	Showing all blog posts
+</span>
 <div class="blogList">
 	{#each items as item}
-		{@const kind = item.kind ?? 'article'}
-		{@const external = item.external === true}
+		{const kind = $derived(item.kind ?? 'article')}
+		{const external = $derived(item.external === true)}
 		<div
 			class="blogItem"
 			data-blog-item
@@ -49,20 +52,26 @@
 				href={item.link}
 				rel={item.link.startsWith('http') ? 'noopener noreferrer' : undefined}
 				target={item.link.startsWith('http') ? '_blank' : undefined}
-				><div class="blogEntryContent">
+			>
+				<div class="blogEntryContent">
 					<span
-						class={`${external ? externalKindIcons[kind] : 'icon-[simple-icons--markdown]'} blogEntryIcon`}
+						class={[
+							external ? externalKindIcons[kind] : 'icon-[simple-icons--markdown]',
+							'blogEntryIcon',
+						]}
 						title={external ? externalKindLabels[kind] : undefined}
 						aria-hidden="true"
 					></span>
 					<p class="blogEntryTitle" style={`view-transition-name:blog-${item.slug}`}>
-						{#if item.draft === true}<span class="blogEntryDraft">(draft)</span
-							>{/if}{' '}{item.title}<span class="blogEntryDate"
-							>{formatDate(new Date(item.pubDate))}</span
-						>
+						{#if item.draft === true}
+							<span class="blogEntryDraft">(draft)</span>
+						{/if}
+						{item.title}<span class="blogEntryDate">
+							{formatDate(new Date(item.pubDate))}
+						</span>
 					</p>
-				</div></a
-			>
+				</div>
+			</a>
 		</div>
 	{/each}
 </div>

--- a/src/pages/blog/[slug]/Article.svelte
+++ b/src/pages/blog/[slug]/Article.svelte
@@ -33,40 +33,48 @@
 </script>
 
 <div class="articlePage">
-	{#if !post.isPublished}<p class="articleUnpublished">This article is not published yet.</p>{/if}
+	{#if !post.isPublished}
+		<p class="articleUnpublished">This article is not published yet.</p>
+	{/if}
 	<hgroup class="articleHeading">
 		<h1 class="articleTitle" style={`view-transition-name:blog-${post.filename}`}>{title}</h1>
 		<p class="articleMeta">
-			{date} ・ {#if post.readingTime < 1}{'Under a minute'}{:else}{`${post.readingTime} min read`}{/if}
-			・{' '}<a
+			{date} ・
+			{#if post.readingTime < 1}
+				Under a minute
+			{:else}
+				{`${post.readingTime} min read`}
+			{/if}
+			・
+			<a
 				class="articleSourceLink"
 				aria-label="Markdown source"
 				href={markdownPath}
 				rel="noopener noreferrer"
 				target="_blank"
-				><span class={`icon-[ri--markdown-line] articleSourceIcon`} aria-hidden="true"></span></a
 			>
+				<span class={['icon-[ri--markdown-line]', 'articleSourceIcon']} aria-hidden="true"></span>
+			</a>
 		</p>
 	</hgroup>
-	<div class="articleDivider"><hr /></div>
-	<article class={`content articleContent articleBody prose`}>{@html post.html}</article>
+	<div class="articleDivider">
+		<hr />
+	</div>
+	<article class={['content', 'articleContent', 'articleBody', 'prose']}>{@html post.html}</article>
 	<div class="articleFooterBlock">
-		<span class="articleFooterLabel">comment on</span>{' '}<a
-			href={blueskyUrl}
-			rel="noopener noreferrer"
-			target="_blank">bluesky</a
-		><span class="articleFooterSeparator"> / </span><a
-			href={tweetUrl}
-			rel="noopener noreferrer"
-			target="_blank">twitter</a
-		>
+		<span class="articleFooterLabel">comment on</span>
+		<a href={blueskyUrl} rel="noopener noreferrer" target="_blank">bluesky</a>
+		<span class="articleFooterSeparator">/</span>
+		<a href={tweetUrl} rel="noopener noreferrer" target="_blank">twitter</a>
 	</div>
 	<div class="articleFooterBlock">
 		<a
 			href="https://creativecommons.org/licenses/by-nc-sa/4.0/"
 			rel="noopener noreferrer"
-			target="_blank">{SITE_COPYRIGHT}</a
+			target="_blank"
 		>
+			{SITE_COPYRIGHT}
+		</a>
 	</div>
 </div>
 

--- a/src/pages/sponsors/Sponsors.svelte
+++ b/src/pages/sponsors/Sponsors.svelte
@@ -1,5 +1,5 @@
 <div class="sponsorsPage">
-	<h1 class={`sponsorsTitle visuallyHidden`}>Sponsors</h1>
+	<h1 class={['sponsorsTitle', 'visuallyHidden']}>Sponsors</h1>
 	<p class="sponsorsMessage">
 		Thank you to everyone supporting my work—it keeps the OSS, blog, and talks alive.
 	</p>
@@ -8,18 +8,24 @@
 			class="sponsorsLink"
 			href="https://github.com/sponsors/ryoppippi"
 			rel="noreferrer"
-			target="_blank"><span class="icon-[ph--heart]" aria-hidden="true"></span>GitHub Sponsors</a
+			target="_blank"
 		>
+			<span class="icon-[ph--heart]" aria-hidden="true"></span>
+			GitHub Sponsors
+		</a>
 	</p>
 	<button
 		class="sponsorsToggle"
 		aria-controls="sponsor-image"
 		aria-describedby="sponsor-view-status"
 		data-sponsor-view="circles"
-		type="button">Show Sponsor Tiers</button
-	><span id="sponsor-view-status" class="visuallyHidden" aria-live="polite"
-		>Showing Sponsor Circles</span
+		type="button"
 	>
+		Show Sponsor Tiers
+	</button>
+	<span id="sponsor-view-status" class="visuallyHidden" aria-live="polite">
+		Showing Sponsor Circles
+	</span>
 	<div class="sponsorsImageFrame">
 		<img
 			id="sponsor-image"

--- a/src/pages/works/media/Media.svelte
+++ b/src/pages/works/media/Media.svelte
@@ -38,38 +38,44 @@
 		href="/works/media/feed.xml"
 		rel="alternate"
 		target="_blank"
-		type="application/rss+xml"><span class="icon-[line-md--rss]" aria-hidden="true"></span>Feed</a
-	>{#if playlist != null}<a
-			class="mediaControlLink"
-			href={playlist.link}
-			rel="noopener noreferrer"
-			target="_blank"
-			><span class="icon-[ri--youtube-line]" aria-hidden="true"></span>Watch all videos on YouTube</a
-		>{/if}<button class="mediaFilter" aria-pressed="false" data-media-filter="english" type="button"
-		><span class="icon-[carbon--checkbox]" aria-hidden="true"></span>English Only</button
+		type="application/rss+xml"
 	>
+		<span class="icon-[line-md--rss]" aria-hidden="true"></span>
+		Feed
+	</a>
+	{#if playlist != null}
+		<a class="mediaControlLink" href={playlist.link} rel="noopener noreferrer" target="_blank">
+			<span class="icon-[ri--youtube-line]" aria-hidden="true"></span>
+			Watch all videos on YouTube
+		</a>
+	{/if}
+	<button class="mediaFilter" aria-pressed="false" data-media-filter="english" type="button">
+		<span class="icon-[carbon--checkbox]" aria-hidden="true"></span>
+		English Only
+	</button>
 </div>
 {#each byYear as [year, yearItems]}
-	<WorksSection title={year} filter="media"
-		><WorksList
-			>{#each yearItems as item}
-				{@const details = kindDetails[item.kind ?? 'podcast']}
+	<WorksSection title={year} filter="media">
+		<WorksList>
+			{#each yearItems as item}
+				{const details = $derived(kindDetails[item.kind ?? 'podcast'])}
 				<li class="mediaItem" data-media-item data-lang={item.lang ?? 'ja'}>
 					<h3 class="mediaTitle">
-						<a class="mediaLink" href={item.link} rel="noopener noreferrer" target="_blank"
-							>{item.title}</a
-						>
+						<a class="mediaLink" href={item.link} rel="noopener noreferrer" target="_blank">
+							{item.title}
+						</a>
 					</h3>
 					<p class="mediaMeta">
-						<span class={`${details.icon} mediaKindIcon`} aria-hidden="true"
-						></span>{details.label}<time class="mediaDate" datetime={item.pubDate}
-							>{formatDate(new Date(item.pubDate))}</time
-						>
+						<span class={[details.icon, 'mediaKindIcon']} aria-hidden="true"></span>
+						{details.label}
+						<time class="mediaDate" datetime={item.pubDate}>
+							{formatDate(new Date(item.pubDate))}
+						</time>
 					</p>
 				</li>
-			{/each}</WorksList
-		></WorksSection
-	>
+			{/each}
+		</WorksList>
+	</WorksSection>
 {/each}
 
 <style>

--- a/src/pages/works/oss/Oss.svelte
+++ b/src/pages/works/oss/Oss.svelte
@@ -31,46 +31,59 @@
 <div class="ossIntro">
 	<div class="ossActions">
 		<a
-			class={`ossAction ossActionGreen`}
+			class={['ossAction', 'ossActionGreen']}
 			href={`${SITE_ORIGIN}/pr`}
 			rel="noopener noreferrer"
 			target="_blank"
-			><span class="icon-[ph--git-pull-request-duotone]" aria-hidden="true"></span>My Recent PRs</a
-		><a
-			class={`ossAction ossActionBlue`}
+		>
+			<span class="icon-[ph--git-pull-request-duotone]" aria-hidden="true"></span>
+			My Recent PRs
+		</a>
+		<a
+			class={['ossAction', 'ossActionBlue']}
 			href={`${SITE_ORIGIN}/gh`}
 			rel="noopener noreferrer"
 			target="_blank"
-			><span class="icon-[ph--github-logo-duotone]" aria-hidden="true"></span>GitHub</a
-		><a
-			class={`ossAction ossActionPink`}
+		>
+			<span class="icon-[ph--github-logo-duotone]" aria-hidden="true"></span>
+			GitHub
+		</a>
+		<a
+			class={['ossAction', 'ossActionPink']}
 			href={`${SITE_ORIGIN}/gh-by-stars`}
 			rel="noopener noreferrer"
-			target="_blank"><span class="icon-[ph--star]" aria-hidden="true"></span>Sort by Stars</a
+			target="_blank"
 		>
+			<span class="icon-[ph--star]" aria-hidden="true"></span>
+			Sort by Stars
+		</a>
 	</div>
 	<p class="ossUpdatedNote">GitHub star counts for my repositories are refreshed daily.</p>
 </div>
 <div class="ossGroups">
 	{#each projectGroups as group}
-		{@const groupProjects = projects.filter((project) => project.kind === group.kind)}
-		{#if groupProjects.length > 0}<WorksSection title={group.title}
-				><div class="ossProjectGrid">
+		{const groupProjects = $derived(projects.filter((project) => project.kind === group.kind))}
+		{#if groupProjects.length > 0}
+			<WorksSection title={group.title}>
+				<div class="ossProjectGrid">
 					{#each groupProjects as project}
-						<a class="ossProject" href={project.link} rel="noopener noreferrer" target="_blank"
-							><div class="ossProjectIcon">
-								<span class={`${project.icon} ossProjectIconGlyph`} aria-hidden="true"></span>
+						<a class="ossProject" href={project.link} rel="noopener noreferrer" target="_blank">
+							<div class="ossProjectIcon">
+								<span class={[project.icon, 'ossProjectIconGlyph']} aria-hidden="true"></span>
 							</div>
 							<div class="ossProjectBody">
 								<div class="ossProjectHeading">
 									<div class="ossProjectName">{project.name}</div>
-									{#if project.stars != null}<span
+									{#if project.stars != null}
+										<span
 											class="ossProjectStars"
 											aria-label={`${project.stars.toLocaleString('en-US')} GitHub stars`}
 											title={`${project.stars.toLocaleString('en-US')} GitHub stars`}
-											><span class={`icon-[ph--star] ossStarIcon`} aria-hidden="true"
-											></span>{formatStars(project.stars)}</span
-										>{/if}
+										>
+											<span class={['icon-[ph--star]', 'ossStarIcon']} aria-hidden="true"></span>
+											{formatStars(project.stars)}
+										</span>
+									{/if}
 								</div>
 								<p class="ossProjectDescription">{project.description ?? ''}</p>
 								<div class="ossProjectTags">
@@ -78,11 +91,12 @@
 										<span class="ossProjectTag">{tag}</span>
 									{/each}
 								</div>
-							</div></a
-						>
+							</div>
+						</a>
 					{/each}
-				</div></WorksSection
-			>{:else}{/if}
+				</div>
+			</WorksSection>
+		{/if}
 	{/each}
 </div>
 

--- a/src/pages/works/publications/Publications.svelte
+++ b/src/pages/works/publications/Publications.svelte
@@ -21,19 +21,20 @@
 </script>
 
 <div class="publicationsPage">
-	<WorksNav active="publications"></WorksNav>{#each years as [year, items]}
-		<WorksSection title={year}
-			><WorksList
-				>{#each items as item}
+	<WorksNav active="publications"></WorksNav>
+	{#each years as [year, items]}
+		<WorksSection title={year}>
+			<WorksList>
+				{#each items as item}
 					<li class="publicationItem">
-						<a class="publicationLink" href={item.link} rel="noopener noreferrer" target="_blank"
-							>{item.title}</a
-						>
+						<a class="publicationLink" href={item.link} rel="noopener noreferrer" target="_blank">
+							{item.title}
+						</a>
 						<p class="publicationPublisher">{item.publisher}</p>
 					</li>
-				{/each}</WorksList
-			></WorksSection
-		>
+				{/each}
+			</WorksList>
+		</WorksSection>
 	{/each}
 </div>
 

--- a/src/pages/works/showcase/Showcase.svelte
+++ b/src/pages/works/showcase/Showcase.svelte
@@ -15,26 +15,27 @@
 <WorksNav active="showcase"></WorksNav>
 <div class="showcaseGrid">
 	{#each projects as project}
-		{@const external = project.link.startsWith('http')}
+		{const external = $derived(project.link.startsWith('http'))}
 		<article class="showcaseCard">
 			<a
 				class="showcaseImageLink"
 				href={project.link}
 				rel={external ? 'noopener noreferrer' : undefined}
 				target={external ? '_blank' : undefined}
-				>{#if project.image != null}<img
-						class="showcaseImage"
-						alt={project.title}
-						src={project.image}
-					/>{/if}</a
 			>
+				{#if project.image != null}
+					<img class="showcaseImage" alt={project.title} src={project.image} />
+				{/if}
+			</a>
 			<div class="showcaseDetails">
 				<h2 class="showcaseTitle">
 					<a
 						href={project.link}
 						rel={external ? 'noopener noreferrer' : undefined}
-						target={external ? '_blank' : undefined}>{project.title}</a
+						target={external ? '_blank' : undefined}
 					>
+						{project.title}
+					</a>
 				</h2>
 				<div class="prose">{@html project.html}</div>
 				<p class="showcaseDate">{formatDate(new Date(project.pubDate))}</p>

--- a/src/pages/works/talks/Talks.svelte
+++ b/src/pages/works/talks/Talks.svelte
@@ -28,47 +28,57 @@
 			class="talksControlLink"
 			href="https://talks.ryoppippi.com/feed.xml"
 			rel="noopener noreferrer"
-			target="_blank"><span class="icon-[line-md--rss]" aria-hidden="true"></span>Feed</a
-		><a class="talksControlLink" href="/yt-talks" rel="noopener noreferrer" target="_blank"
-			><span class="icon-[ri--youtube-line]" aria-hidden="true"></span>Watch all talks on YouTube</a
-		><button class="talksFilter" aria-pressed="false" data-talk-filter="english" type="button"
-			><span class="icon-[carbon--checkbox]" aria-hidden="true"></span>English Only</button
+			target="_blank"
 		>
+			<span class="icon-[line-md--rss]" aria-hidden="true"></span>
+			Feed
+		</a>
+		<a class="talksControlLink" href="/yt-talks" rel="noopener noreferrer" target="_blank">
+			<span class="icon-[ri--youtube-line]" aria-hidden="true"></span>
+			Watch all talks on YouTube
+		</a>
+		<button class="talksFilter" aria-pressed="false" data-talk-filter="english" type="button">
+			<span class="icon-[carbon--checkbox]" aria-hidden="true"></span>
+			English Only
+		</button>
 	</div>
 	{#each byYear as [year, items]}
-		<WorksSection title={year} filter="talk"
-			><WorksList
-				>{#each items as talk}
-					{@const link = talk.links.at(0)}
-					{@const event = talk.event === 'テックワールド' ? 'TECH WORLD' : talk.event}
+		<WorksSection title={year} filter="talk">
+			<WorksList>
+				{#each items as talk}
+					{const link = $derived(talk.links.at(0))}
+					{const event = $derived(talk.event === 'テックワールド' ? 'TECH WORLD' : talk.event)}
 					<li class="talkItem" data-talk-item data-lang={talk.lang ?? 'en'}>
 						<h3 class="talkTitle">
-							{#if link == null}{talk.title}{:else}<a
-									class="talkLink"
-									href={link}
-									rel="noopener noreferrer"
-									target="_blank">{talk.title}</a
-								>{/if}
+							{#if link == null}
+								{talk.title}
+							{:else}
+								<a class="talkLink" href={link} rel="noopener noreferrer" target="_blank">
+									{talk.title}
+								</a>
+							{/if}
 						</h3>
 						<p class="talkMeta">
-							{#if talk.eventLink == null}{event}{:else}<a
-									class="talkLink"
-									href={talk.eventLink}
-									rel="noopener noreferrer"
-									target="_blank">{event}</a
-								>{/if}<time class="talkDate" datetime={talk.date}
-								>{formatDate(new Date(talk.date))}</time
-							>
+							{#if talk.eventLink == null}
+								{event}
+							{:else}
+								<a class="talkLink" href={talk.eventLink} rel="noopener noreferrer" target="_blank">
+									{event}
+								</a>
+							{/if}
+							<time class="talkDate" datetime={talk.date}>{formatDate(new Date(talk.date))}</time>
 						</p>
-						{#if talk.videoLink != null}<p class="talkVideo">
-								<a class="talkLink" href={talk.videoLink} rel="noopener noreferrer" target="_blank"
-									>Watch the video</a
-								>
-							</p>{/if}
+						{#if talk.videoLink != null}
+							<p class="talkVideo">
+								<a class="talkLink" href={talk.videoLink} rel="noopener noreferrer" target="_blank">
+									Watch the video
+								</a>
+							</p>
+						{/if}
 					</li>
-				{/each}</WorksList
-			></WorksSection
-		>
+				{/each}
+			</WorksList>
+		</WorksSection>
 	{/each}
 </div>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -109,6 +109,7 @@ export default defineConfig(({ command, mode }) => {
 		},
 		fmt: {
 			svelte: true,
+			overrides: [{ files: ['**/*.svelte'], options: { htmlWhitespaceSensitivity: 'css' } }],
 			ignorePatterns: [
 				'.cache/**',
 				'.claude/**',


### PR DESCRIPTION
Make Svelte markup easier to read: put nested elements and `if`/`else`/`each` boundaries on separate lines, replace JSX-style space and fixed-string expressions with normal text, and use Svelte class arrays for combined and conditional classes. Render the chart legend with one typed `each` loop and remove the empty OSS-group `else` branch.

Replace all nine legacy `{@const}` declarations with `{const value = $derived(...)}`. `$derived` preserves their dependency tracking when props change; the server render still computes the same values. See [Svelte declaration tags](https://svelte.dev/docs/svelte/declaration-tags).

Oxfmt remains the formatter. Keep CSS whitespace sensitivity so inline punctuation and the blog title/date spacing stay intact. This PR is based independently on main and does not include the ox-content 3.1.4 adoption in #2142.

Validation:
- `pnpm check`: Oxfmt and type checks pass; svelte-check reports zero errors/warnings. One pre-existing `no-control-regex` warning remains in the benchmark script.
- `pnpm test`: all 39 tests pass across 12 files.
- `node_modules/.bin/vpr --no-cache build`: rsvelte successfully generates all 428 outputs using the declaration tags and class arrays.
- Compared SSG before/after for home, About, OSS, blog listing and the English GTV article. Site-owned class tokens match; About prose and the Works tagline retain their spacing. Browser checks at 1440px and 390px found identical positions/sizes for the selected headers, prose, lists, legend and table rows, with no mobile page overflow. A title/date spacing difference introduced by line breaks was corrected before the final comparison.
- Production hydration: five legend entries, 18 table rows, reveal class applied and one focused row highlighted. Keyboard focus updates the live readout; no browser warnings or errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies Svelte markup across the site and replaces all `{@const}` declarations with Svelte 5 `{const value = $derived(...)}` declaration tags. `$derived` preserves dependency tracking when props change, and server-rendered output is unchanged.

**Refactors**
- Nested elements and block boundaries now start on their own lines; JSX-style space expressions become plain text.
- Combined and conditional classes use Svelte class arrays instead of template literals.
- The chart legend renders from a single typed `each` loop, and the empty OSS-group `else` branch is gone.
- Adds an `htmlWhitespaceSensitivity: 'css'` override in `vite.config.ts` so inline punctuation and title/date spacing stay intact.

<sup>Written for commit 2be6852c747f9902efdce978ccf989664e596cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

