### PR TITLE
revert(mcp): restore Svelte server configuration

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+experimental_use_rmcp_client = true
+
+[mcp_servers.svelte]
+url = "https://mcp.svelte.dev/mcp"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"svelte": {
+			"type": "http",
+			"url": "https://mcp.svelte.dev/mcp"
+		}
+	}
+}


### PR DESCRIPTION
Revert the Svelte MCP configuration removal in #2138 (9aa31654b82c0df3bd01c997fe11514f22843743), now that the site uses Svelte again. Restore `.mcp.json` and `.codex/config.toml` exactly as they were before that commit, pointing to the hosted Svelte MCP server.

Validation: both files are byte-for-byte identical to their pre-removal versions; JSON and TOML parsing and `git diff --check` pass. No application code changes. Live MCP connection was not tested in this session.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Svelte MCP server configuration that was removed in #2138, now that the site uses Svelte again. Re-adds `.mcp.json` and `.codex/config.toml` pointing to the hosted Svelte MCP server.

**Validation**
- Both files are byte-for-byte identical to their pre-removal versions.
- JSON and TOML parsing and `git diff --check` pass; no application code changes.
- Live MCP connection was not tested.

<sup>Written for commit bf33a36e1362111e5fdfbb6c6696631c3052a8ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

