### PR TITLE
refactor(chart): derive legend entries from translated copy

### DIFF
--- a/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/Legend.svelte
+++ b/src/content/blog/2026-07-30-uk-gtv-ja/gtv-chart/Legend.svelte
@@ -4,20 +4,13 @@
 
 	let { lang }: { lang?: ChartLang } = $props();
 	const copy = $derived(uiCopy[resolveChartLang(lang)].legend);
-	const items = [
-		'mid',
-		'high',
-		'low',
-		'stars',
-		'after',
-	] as const satisfies readonly (keyof typeof copy)[];
 </script>
 
 <ul class="legend">
-	{#each items as item}
+	{#each Object.entries(copy) as [key, label]}
 		<li>
-			<span aria-hidden="true" class={['swatch', `swatch--${item}`]}></span>
-			{copy[item]}
+			<span aria-hidden="true" class={['swatch', `swatch--${key}`]}></span>
+			{label}
 		</li>
 	{/each}
 </ul>


### PR DESCRIPTION
Render legend key/label pairs directly from `Object.entries(copy)` and remove the separately maintained key list. Svelte's second `each` binding is an array index, not an object key; destructuring entries supplies both the swatch key and translated label. The existing non-index string keys retain property creation order in both translations (`mid`, `high`, `low`, `stars`, `after`).

Validation: Oxfmt, lint/type checks and svelte-check passed with no warnings; `node_modules/.bin/vpr --no-cache build` generated 428 outputs. Checked the generated Japanese and English legend HTML for all five labels, their order and matching swatch classes. Browser interaction was not re-tested for this data-enumeration-only change.

References: [Svelte each blocks](https://svelte.dev/docs/svelte/each), [ECMAScript property ordering](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryownpropertykeys).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders the chart legend directly from the translated copy instead of a separately maintained key list, so the legend can't get out of sync with the translations. The visible legend output and label order are unchanged.

<sup>Written for commit b89e0a6cdbdaf5815c1e365ef5a8c0310c9bb39c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ryoppippi.com/pull/2146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

