### PR TITLE
feat(content): validate blog permalinks during collection builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,5 @@ jobs:
             run: pnpm run check
           - name: Run Tests
             run: pnpm run test
+          - name: Validate Content
+            run: pnpm run validate:content

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"preview": "vp preview",
 		"test": "vp test --run",
 		"typos": "typos --force-exclude",
-		"update:oss-stars": "./.github/update-oss-stars.nu"
+		"update:oss-stars": "./.github/update-oss-stars.nu",
+		"validate:content": "oxct validate"
 	},
 	"devDependencies": {
 		"@clack/prompts": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,17 +25,17 @@ catalogs:
       specifier: ^2.2.510
       version: 2.2.520
     '@ox-content/islands':
-      specifier: 3.1.8
-      version: 3.1.8
+      specifier: 3.2.1
+      version: 3.2.1
     '@ox-content/theme-color-kanagawa':
-      specifier: 3.1.8
-      version: 3.1.8
+      specifier: 3.2.1
+      version: 3.2.1
     '@ox-content/vite-plugin':
-      specifier: 3.1.8
-      version: 3.1.8
+      specifier: 3.2.1
+      version: 3.2.1
     '@ox-content/vite-plugin-svelte':
-      specifier: 3.1.8
-      version: 3.1.8
+      specifier: 3.2.1
+      version: 3.2.1
     '@rsvelte/vite-plugin-svelte':
       specifier: 0.5.2
       version: 0.5.2
@@ -142,16 +142,16 @@ importers:
         version: 2.2.520
       '@ox-content/islands':
         specifier: 'catalog:'
-        version: 3.1.8
+        version: 3.2.1
       '@ox-content/theme-color-kanagawa':
         specifier: 'catalog:'
-        version: 3.1.8(@ox-content/vite-plugin@3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))
+        version: 3.2.1(@ox-content/vite-plugin@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))
       '@ox-content/vite-plugin':
         specifier: 'catalog:'
-        version: 3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+        version: 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
       '@ox-content/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+        version: 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
       '@rsvelte/vite-plugin-svelte':
         specifier: 'catalog:'
         version: 0.5.2(@sveltejs/vite-plugin-svelte@6.2.4(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(svelte@5.57.0))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(svelte@5.57.0)
@@ -870,67 +870,67 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ox-content/binding-darwin-arm64@3.1.8':
-    resolution: {integrity: sha512-yo4q8vewpFhlKUqHl4bF2oxw/I7jCWkkwww7qzZXtBj20yIwy8U6fBFbiIzWFACcQyxTfrco+0G7Ob/W2l2SZQ==}
+  '@ox-content/binding-darwin-arm64@3.2.1':
+    resolution: {integrity: sha512-7HSFdfsbl2tPneKEeoa0vfwcY098vjUR7JAgYxXZDjCjnpTxp1TkIndCxWP8cxUlVNHUDDAc8A7VBlaXS2u5rQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ox-content/binding-darwin-x64@3.1.8':
-    resolution: {integrity: sha512-yqKsFtk5GOtcP8eqPjfYbC8ATpXKecvsARtbT4f02yBoeNC+3ycCBO50+xUGPH+oNtr5NwWnlpVd4fq7YzsXRw==}
+  '@ox-content/binding-darwin-x64@3.2.1':
+    resolution: {integrity: sha512-3aaGAjbaItWwuOA8zSVBbLflUzU585DwIs+Ka6xjwDza7asFh5KTOV16tm6FsKhnIZT49kF0GPq2LKkEc1c5ew==}
     cpu: [x64]
     os: [darwin]
 
-  '@ox-content/binding-linux-arm64-gnu@3.1.8':
-    resolution: {integrity: sha512-/yiNMmrmvdeDvDHw65x5nZ49ykzjjhzxnNgRDjvjSGtX+QIrWxeJ+8Jiki+1oqr1iBJvYfJkw3kYPN9stxMaqw==}
+  '@ox-content/binding-linux-arm64-gnu@3.2.1':
+    resolution: {integrity: sha512-n0qBzTA0utAX6gojEXv0x+9cUcL1sitKI4ayL4vnUypa8Ol1jUZIPIKL3Lra+pGKp60hukQBfeDiaVDKYU80+Q==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ox-content/binding-linux-arm64-musl@3.1.8':
-    resolution: {integrity: sha512-GKE3TiANdiZpoaa+UaJRywyHgamO6SBmkgykqbeAP6bjHxYenpeq2yLfmxHFRGo/hucM4JSfolJ2Pp60e8KC7A==}
+  '@ox-content/binding-linux-arm64-musl@3.2.1':
+    resolution: {integrity: sha512-170ewY3U/4dBMZZWx50bK6jNOgyqUQe1rNemmmV53EfmnqoUZ0wd0yPr9NDJFX4ufadwZ/xq3++ZqL0unsTMPQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@ox-content/binding-linux-x64-gnu@3.1.8':
-    resolution: {integrity: sha512-gMT/tpklmU7ajmEzm8hTEworq/PKowYZPwfiEePn+05RK5rzUPs8s+hC230OJLSIZqcjhW58w0I2Yer9Hc7cYg==}
+  '@ox-content/binding-linux-x64-gnu@3.2.1':
+    resolution: {integrity: sha512-wwITF79WRpsnx0VmdmSTqBt7WQ6nU3xwgs0UwOfNsKP/zKE9t+iziuOULPGF9R5aVMA86MNiuvLE7I/NOdF03g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ox-content/binding-linux-x64-musl@3.1.8':
-    resolution: {integrity: sha512-429kDv8TrP+CKEWT2LwKsWg2EBPcT6RJYXwxfaFttCOcjWUkS2P+mknFq5bsWB8SnsbbE2c0GUAknOqekWIfag==}
+  '@ox-content/binding-linux-x64-musl@3.2.1':
+    resolution: {integrity: sha512-/UksYfYRlOZzuwf7Dlw5xAKQx/yF9gerz01gVcnUSM+mTOj8KycavmiDlSDOBiIBQS67tVEFqaOWYNlN7z6V5g==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@ox-content/binding-win32-x64-msvc@3.1.8':
-    resolution: {integrity: sha512-kmXdrjLTL2zeqxfUWDp74UNFMmA3BOfH2aX8+89upQCrVrSZXxKp6DrrlpwuMZ2saYKRAAXWesXDfYQKDbsddw==}
+  '@ox-content/binding-win32-x64-msvc@3.2.1':
+    resolution: {integrity: sha512-NKZBinFM/6pkww/FCQtexZAF+mJZmeQNG60cck85Zo5zjKRHEDK28eBPXHEfqgEntOjFIIlB9eD0pjOOHY4xLQ==}
     cpu: [x64]
     os: [win32]
 
-  '@ox-content/islands@3.1.8':
-    resolution: {integrity: sha512-IRkvhEEWXOa8PMCUEmedDcX1aoZU57GGjcqWoSEM+8pQakEoFkb1cR30Jvf3GR6XT2g0tSz4plfZUD5Yoe5TpA==}
+  '@ox-content/islands@3.2.1':
+    resolution: {integrity: sha512-q+YV0WoIEBQl2s5ToVnWHs6b3J7Kx/HEoUxgCfDYXvmDBDgA0BRfrv4Mdp0EkaS6+NMAowaFU5dZu/KzZnlBUg==}
 
-  '@ox-content/napi@3.1.8':
-    resolution: {integrity: sha512-Voq1+M8dmPGFmnY1Pg9Gkf4gPyHnRnN2FgFnQlkG2kB5FhiwPjh86o2vPGJLOvRNqnqvmsueO4eu9KFbey+brQ==}
+  '@ox-content/napi@3.2.1':
+    resolution: {integrity: sha512-qAJSf4iTxv+qbkOKZ5OaL4cDlneur//oGn4UbsIm4jiqIC7o/GdDcnAx8yqSrAkJuu9h//FwxI/O9h4ofjMWfg==}
 
-  '@ox-content/theme-color-kanagawa@3.1.8':
-    resolution: {integrity: sha512-5NvZYNCOVapmnZr/cdRjOEXnqaE64ppdpUGGf8yKDzGKTsBLM+NjAApHH9GmlTah35R1PblsSTe7YYHkeshIQA==}
+  '@ox-content/theme-color-kanagawa@3.2.1':
+    resolution: {integrity: sha512-I25uT95MerTvAeGKOZb+H1yreVXHs71qHuZVXeCNWka/kjh8ChYl56/FgCiV+70I//bn7X+8YoWyDwgt4Xj8Gg==}
     peerDependencies:
       '@ox-content/vite-plugin': '>=3.0.0-alpha.1'
     peerDependenciesMeta:
       '@ox-content/vite-plugin':
         optional: true
 
-  '@ox-content/vite-plugin-svelte@3.1.8':
-    resolution: {integrity: sha512-AFyjc7iPcm0x7HtRW/wHMUU2b5npIhDHNr0xgmgS1XEwYgEYU4aKSlAy5xE5mHW/FLf61GILsdfli7j5cy41fA==}
+  '@ox-content/vite-plugin-svelte@3.2.1':
+    resolution: {integrity: sha512-/cT+GaRItF2HeZFZGlrOklBn2D5UNpZyEJhDCYub0llZMEHiuhd2dO9ED9ZoS2+dICFEpF4unvVx1tOSMyWLMg==}
     peerDependencies:
       svelte: ^5.56.10
       vite: ^0.2.8 || ^8.0.0
 
-  '@ox-content/vite-plugin@3.1.8':
-    resolution: {integrity: sha512-k+YQMXc99+9Sm9w7sPtiJ70HPqVJofaAfpC7q3f7kWxUQUzkgaj6zVn5SwmUv8RRl41daFX5lHszzgkpM3cWPg==}
+  '@ox-content/vite-plugin@3.2.1':
+    resolution: {integrity: sha512-0JFYoduRQ6Bis5YcFyRsZnj82zneYHTPsNlJ7jpuCVNjniy6/SmOoOrwnmS4n/zqqig2mUn1L8SyfDInHXp9jg==}
     hasBin: true
     peerDependencies:
       '@vue/compiler-sfc': ^3.4.0
@@ -4848,47 +4848,47 @@ snapshots:
   '@oven/bun-windows-x64@1.4.2':
     optional: true
 
-  '@ox-content/binding-darwin-arm64@3.1.8':
+  '@ox-content/binding-darwin-arm64@3.2.1':
     optional: true
 
-  '@ox-content/binding-darwin-x64@3.1.8':
+  '@ox-content/binding-darwin-x64@3.2.1':
     optional: true
 
-  '@ox-content/binding-linux-arm64-gnu@3.1.8':
+  '@ox-content/binding-linux-arm64-gnu@3.2.1':
     optional: true
 
-  '@ox-content/binding-linux-arm64-musl@3.1.8':
+  '@ox-content/binding-linux-arm64-musl@3.2.1':
     optional: true
 
-  '@ox-content/binding-linux-x64-gnu@3.1.8':
+  '@ox-content/binding-linux-x64-gnu@3.2.1':
     optional: true
 
-  '@ox-content/binding-linux-x64-musl@3.1.8':
+  '@ox-content/binding-linux-x64-musl@3.2.1':
     optional: true
 
-  '@ox-content/binding-win32-x64-msvc@3.1.8':
+  '@ox-content/binding-win32-x64-msvc@3.2.1':
     optional: true
 
-  '@ox-content/islands@3.1.8': {}
+  '@ox-content/islands@3.2.1': {}
 
-  '@ox-content/napi@3.1.8':
+  '@ox-content/napi@3.2.1':
     optionalDependencies:
-      '@ox-content/binding-darwin-arm64': 3.1.8
-      '@ox-content/binding-darwin-x64': 3.1.8
-      '@ox-content/binding-linux-arm64-gnu': 3.1.8
-      '@ox-content/binding-linux-arm64-musl': 3.1.8
-      '@ox-content/binding-linux-x64-gnu': 3.1.8
-      '@ox-content/binding-linux-x64-musl': 3.1.8
-      '@ox-content/binding-win32-x64-msvc': 3.1.8
+      '@ox-content/binding-darwin-arm64': 3.2.1
+      '@ox-content/binding-darwin-x64': 3.2.1
+      '@ox-content/binding-linux-arm64-gnu': 3.2.1
+      '@ox-content/binding-linux-arm64-musl': 3.2.1
+      '@ox-content/binding-linux-x64-gnu': 3.2.1
+      '@ox-content/binding-linux-x64-musl': 3.2.1
+      '@ox-content/binding-win32-x64-msvc': 3.2.1
 
-  '@ox-content/theme-color-kanagawa@3.1.8(@ox-content/vite-plugin@3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))':
+  '@ox-content/theme-color-kanagawa@3.2.1(@ox-content/vite-plugin@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))':
     optionalDependencies:
-      '@ox-content/vite-plugin': 3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+      '@ox-content/vite-plugin': 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
 
-  '@ox-content/vite-plugin-svelte@3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
+  '@ox-content/vite-plugin-svelte@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
     dependencies:
-      '@ox-content/islands': 3.1.8
-      '@ox-content/vite-plugin': 3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+      '@ox-content/islands': 3.2.1
+      '@ox-content/vite-plugin': 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
       svelte: 5.57.0
       vite: '@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0)'
     transitivePeerDependencies:
@@ -4908,14 +4908,14 @@ snapshots:
       - vue
       - yauzl
 
-  '@ox-content/vite-plugin@3.1.8(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
+  '@ox-content/vite-plugin@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
     dependencies:
       '@cspell/dict-de-de': 4.1.2
       '@cspell/dict-en_us': 4.4.37
       '@cspell/dict-fr-fr': 2.3.2
       '@cspell/dict-pl_pl': 3.0.6
       '@mermaid-js/mermaid-cli': 11.17.0(@babel/core@7.29.7)(@babel/template@7.29.7)(puppeteer@25.10.0)(tailwindcss@4.3.3)
-      '@ox-content/napi': 3.1.8
+      '@ox-content/napi': 3.2.1
       '@resvg/resvg-js': 2.6.2
       clean-css: 5.3.3
       cspell-lib: 10.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,17 +25,17 @@ catalogs:
       specifier: ^2.2.510
       version: 2.2.520
     '@ox-content/islands':
-      specifier: 3.2.1
-      version: 3.2.1
+      specifier: 3.2.2
+      version: 3.2.2
     '@ox-content/theme-color-kanagawa':
-      specifier: 3.2.1
-      version: 3.2.1
+      specifier: 3.2.2
+      version: 3.2.2
     '@ox-content/vite-plugin':
-      specifier: 3.2.1
-      version: 3.2.1
+      specifier: 3.2.2
+      version: 3.2.2
     '@ox-content/vite-plugin-svelte':
-      specifier: 3.2.1
-      version: 3.2.1
+      specifier: 3.2.2
+      version: 3.2.2
     '@rsvelte/vite-plugin-svelte':
       specifier: 0.5.2
       version: 0.5.2
@@ -142,16 +142,16 @@ importers:
         version: 2.2.520
       '@ox-content/islands':
         specifier: 'catalog:'
-        version: 3.2.1
+        version: 3.2.2
       '@ox-content/theme-color-kanagawa':
         specifier: 'catalog:'
-        version: 3.2.1(@ox-content/vite-plugin@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))
+        version: 3.2.2(@ox-content/vite-plugin@3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))
       '@ox-content/vite-plugin':
         specifier: 'catalog:'
-        version: 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+        version: 3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
       '@ox-content/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+        version: 3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
       '@rsvelte/vite-plugin-svelte':
         specifier: 'catalog:'
         version: 0.5.2(@sveltejs/vite-plugin-svelte@6.2.4(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(svelte@5.57.0))(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(svelte@5.57.0)
@@ -870,67 +870,67 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ox-content/binding-darwin-arm64@3.2.1':
-    resolution: {integrity: sha512-7HSFdfsbl2tPneKEeoa0vfwcY098vjUR7JAgYxXZDjCjnpTxp1TkIndCxWP8cxUlVNHUDDAc8A7VBlaXS2u5rQ==}
+  '@ox-content/binding-darwin-arm64@3.2.2':
+    resolution: {integrity: sha512-92vTT3ZkX53gdm+rjLPe/k3s7AKrOnTR2CSCxyBrh3MlwOWAzDVt6vgISsgr8HfV3dZUxvDqBL9MIsSIODfkRw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ox-content/binding-darwin-x64@3.2.1':
-    resolution: {integrity: sha512-3aaGAjbaItWwuOA8zSVBbLflUzU585DwIs+Ka6xjwDza7asFh5KTOV16tm6FsKhnIZT49kF0GPq2LKkEc1c5ew==}
+  '@ox-content/binding-darwin-x64@3.2.2':
+    resolution: {integrity: sha512-gfqzMucNiEAPM9VjtsZJ00WwNxoRufqa8Ahb1XTNvcRVXSVKlK/IfTBC2r3/uSpkjz6qCEKiRluWBcuQPdMnUQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@ox-content/binding-linux-arm64-gnu@3.2.1':
-    resolution: {integrity: sha512-n0qBzTA0utAX6gojEXv0x+9cUcL1sitKI4ayL4vnUypa8Ol1jUZIPIKL3Lra+pGKp60hukQBfeDiaVDKYU80+Q==}
+  '@ox-content/binding-linux-arm64-gnu@3.2.2':
+    resolution: {integrity: sha512-uGmF9wKNe3AEF8kAIC8qZkBl3khZiu0G3lxovVxIYY4tdbVHMtE1Sc8Bki8ojScE2c9IrwZ565AUTcsRc0VpFA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ox-content/binding-linux-arm64-musl@3.2.1':
-    resolution: {integrity: sha512-170ewY3U/4dBMZZWx50bK6jNOgyqUQe1rNemmmV53EfmnqoUZ0wd0yPr9NDJFX4ufadwZ/xq3++ZqL0unsTMPQ==}
+  '@ox-content/binding-linux-arm64-musl@3.2.2':
+    resolution: {integrity: sha512-3YrDV1WAj3b8aJ65zj+w6o2bJ4p3SsixFoljiY5FUgU1CFxeAE16KrMJGzw9BIvvMJTvJa07d2NfmAukAa9Khw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@ox-content/binding-linux-x64-gnu@3.2.1':
-    resolution: {integrity: sha512-wwITF79WRpsnx0VmdmSTqBt7WQ6nU3xwgs0UwOfNsKP/zKE9t+iziuOULPGF9R5aVMA86MNiuvLE7I/NOdF03g==}
+  '@ox-content/binding-linux-x64-gnu@3.2.2':
+    resolution: {integrity: sha512-lNb7d7iQNArH6BsIfeI/3d2BP9fl2vgfGMI2lwepFCccZ6wmlKI7+HpRSGFmqDoNQuahHaSjsf68oTsMZT/aKQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ox-content/binding-linux-x64-musl@3.2.1':
-    resolution: {integrity: sha512-/UksYfYRlOZzuwf7Dlw5xAKQx/yF9gerz01gVcnUSM+mTOj8KycavmiDlSDOBiIBQS67tVEFqaOWYNlN7z6V5g==}
+  '@ox-content/binding-linux-x64-musl@3.2.2':
+    resolution: {integrity: sha512-iRSDWusKbdlc/8DTNi2APvF9BnVfkmSA/96qfSlRpUrlnWkGELGZalHGZgQzfSRKyvMQUhryqfgsLSvip0TRAA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@ox-content/binding-win32-x64-msvc@3.2.1':
-    resolution: {integrity: sha512-NKZBinFM/6pkww/FCQtexZAF+mJZmeQNG60cck85Zo5zjKRHEDK28eBPXHEfqgEntOjFIIlB9eD0pjOOHY4xLQ==}
+  '@ox-content/binding-win32-x64-msvc@3.2.2':
+    resolution: {integrity: sha512-ml0JwnBKJXXFvwayLmhjNQPRo11B4SS/kHkvf21zcKVYzXeyhgErchgZFrGVmrY1PrvZ34W9IGpeRwGodKSBwQ==}
     cpu: [x64]
     os: [win32]
 
-  '@ox-content/islands@3.2.1':
-    resolution: {integrity: sha512-q+YV0WoIEBQl2s5ToVnWHs6b3J7Kx/HEoUxgCfDYXvmDBDgA0BRfrv4Mdp0EkaS6+NMAowaFU5dZu/KzZnlBUg==}
+  '@ox-content/islands@3.2.2':
+    resolution: {integrity: sha512-eeUPQm93Pi7e+5d2OljRxFVwX5/H59RLiDlVr+XvBtAf18gF4NJnDYOF1GmE1u5QArG+B1tN2zHk0M2NsXijxw==}
 
-  '@ox-content/napi@3.2.1':
-    resolution: {integrity: sha512-qAJSf4iTxv+qbkOKZ5OaL4cDlneur//oGn4UbsIm4jiqIC7o/GdDcnAx8yqSrAkJuu9h//FwxI/O9h4ofjMWfg==}
+  '@ox-content/napi@3.2.2':
+    resolution: {integrity: sha512-dCR5MOR6/ZW91oZssUW9auod2yv9XGkoqkOyrTIIFk2Rc5GBrU4AelaX3brnUAH6a7R1fTFcuOR5SKz6y0yOAQ==}
 
-  '@ox-content/theme-color-kanagawa@3.2.1':
-    resolution: {integrity: sha512-I25uT95MerTvAeGKOZb+H1yreVXHs71qHuZVXeCNWka/kjh8ChYl56/FgCiV+70I//bn7X+8YoWyDwgt4Xj8Gg==}
+  '@ox-content/theme-color-kanagawa@3.2.2':
+    resolution: {integrity: sha512-8nMMIgcqe1WpLCGDuQkYbzRAAkHrTDc56e1Hxl7gBImFRZceFZE22iDf3iLvBQOx2emFT7Lgv44KVkIif7o5bg==}
     peerDependencies:
       '@ox-content/vite-plugin': '>=3.0.0-alpha.1'
     peerDependenciesMeta:
       '@ox-content/vite-plugin':
         optional: true
 
-  '@ox-content/vite-plugin-svelte@3.2.1':
-    resolution: {integrity: sha512-/cT+GaRItF2HeZFZGlrOklBn2D5UNpZyEJhDCYub0llZMEHiuhd2dO9ED9ZoS2+dICFEpF4unvVx1tOSMyWLMg==}
+  '@ox-content/vite-plugin-svelte@3.2.2':
+    resolution: {integrity: sha512-VNgEO9XJ+7Vt6z8L2E17RzXd1h3/3fi36Jxl6SQsXlvwIQWA7LgQ7B1bUiPwvOmSfRMciVdleH0eXbiifFmumg==}
     peerDependencies:
       svelte: ^5.56.10
       vite: ^0.2.8 || ^8.0.0
 
-  '@ox-content/vite-plugin@3.2.1':
-    resolution: {integrity: sha512-0JFYoduRQ6Bis5YcFyRsZnj82zneYHTPsNlJ7jpuCVNjniy6/SmOoOrwnmS4n/zqqig2mUn1L8SyfDInHXp9jg==}
+  '@ox-content/vite-plugin@3.2.2':
+    resolution: {integrity: sha512-NTWTxdYba3b1RCUqd32ATj1k1Zs8CxNbaNvJ0wLO0TriJ7AmX1TkuYyPrMXRQ6jC4o1yWUsoDFgwpWpgOWRcQg==}
     hasBin: true
     peerDependencies:
       '@vue/compiler-sfc': ^3.4.0
@@ -4848,47 +4848,47 @@ snapshots:
   '@oven/bun-windows-x64@1.4.2':
     optional: true
 
-  '@ox-content/binding-darwin-arm64@3.2.1':
+  '@ox-content/binding-darwin-arm64@3.2.2':
     optional: true
 
-  '@ox-content/binding-darwin-x64@3.2.1':
+  '@ox-content/binding-darwin-x64@3.2.2':
     optional: true
 
-  '@ox-content/binding-linux-arm64-gnu@3.2.1':
+  '@ox-content/binding-linux-arm64-gnu@3.2.2':
     optional: true
 
-  '@ox-content/binding-linux-arm64-musl@3.2.1':
+  '@ox-content/binding-linux-arm64-musl@3.2.2':
     optional: true
 
-  '@ox-content/binding-linux-x64-gnu@3.2.1':
+  '@ox-content/binding-linux-x64-gnu@3.2.2':
     optional: true
 
-  '@ox-content/binding-linux-x64-musl@3.2.1':
+  '@ox-content/binding-linux-x64-musl@3.2.2':
     optional: true
 
-  '@ox-content/binding-win32-x64-msvc@3.2.1':
+  '@ox-content/binding-win32-x64-msvc@3.2.2':
     optional: true
 
-  '@ox-content/islands@3.2.1': {}
+  '@ox-content/islands@3.2.2': {}
 
-  '@ox-content/napi@3.2.1':
+  '@ox-content/napi@3.2.2':
     optionalDependencies:
-      '@ox-content/binding-darwin-arm64': 3.2.1
-      '@ox-content/binding-darwin-x64': 3.2.1
-      '@ox-content/binding-linux-arm64-gnu': 3.2.1
-      '@ox-content/binding-linux-arm64-musl': 3.2.1
-      '@ox-content/binding-linux-x64-gnu': 3.2.1
-      '@ox-content/binding-linux-x64-musl': 3.2.1
-      '@ox-content/binding-win32-x64-msvc': 3.2.1
+      '@ox-content/binding-darwin-arm64': 3.2.2
+      '@ox-content/binding-darwin-x64': 3.2.2
+      '@ox-content/binding-linux-arm64-gnu': 3.2.2
+      '@ox-content/binding-linux-arm64-musl': 3.2.2
+      '@ox-content/binding-linux-x64-gnu': 3.2.2
+      '@ox-content/binding-linux-x64-musl': 3.2.2
+      '@ox-content/binding-win32-x64-msvc': 3.2.2
 
-  '@ox-content/theme-color-kanagawa@3.2.1(@ox-content/vite-plugin@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))':
+  '@ox-content/theme-color-kanagawa@3.2.2(@ox-content/vite-plugin@3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3))':
     optionalDependencies:
-      '@ox-content/vite-plugin': 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+      '@ox-content/vite-plugin': 3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
 
-  '@ox-content/vite-plugin-svelte@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
+  '@ox-content/vite-plugin-svelte@3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
     dependencies:
-      '@ox-content/islands': 3.2.1
-      '@ox-content/vite-plugin': 3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
+      '@ox-content/islands': 3.2.2
+      '@ox-content/vite-plugin': 3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)
       svelte: 5.57.0
       vite: '@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0)'
     transitivePeerDependencies:
@@ -4908,14 +4908,14 @@ snapshots:
       - vue
       - yauzl
 
-  '@ox-content/vite-plugin@3.2.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
+  '@ox-content/vite-plugin@3.2.2(@babel/core@7.29.7)(@babel/template@7.29.7)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.13.3)(jiti@2.7.0)(terser@5.51.2)(typescript@6.0.3)(yaml@2.9.0))(budoux@0.9.0)(katex@0.16.47)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.57.0)(tailwindcss@4.3.3)':
     dependencies:
       '@cspell/dict-de-de': 4.1.2
       '@cspell/dict-en_us': 4.4.37
       '@cspell/dict-fr-fr': 2.3.2
       '@cspell/dict-pl_pl': 3.0.6
       '@mermaid-js/mermaid-cli': 11.17.0(@babel/core@7.29.7)(@babel/template@7.29.7)(puppeteer@25.10.0)(tailwindcss@4.3.3)
-      '@ox-content/napi': 3.2.1
+      '@ox-content/napi': 3.2.2
       '@resvg/resvg-js': 2.6.2
       clean-css: 5.3.3
       cspell-lib: 10.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,11 +7,11 @@ catalog:
   '@fontsource/jetbrains-mono': ^5.3.0
   '@fontsource/roboto-condensed': ^5.3.0
   '@iconify/json': ^2.2.510
-  '@ox-content/islands': 3.2.1
-  '@ox-content/napi': 3.2.1
-  '@ox-content/theme-color-kanagawa': 3.2.1
-  '@ox-content/vite-plugin': 3.2.1
-  '@ox-content/vite-plugin-svelte': 3.2.1
+  '@ox-content/islands': 3.2.2
+  '@ox-content/napi': 3.2.2
+  '@ox-content/theme-color-kanagawa': 3.2.2
+  '@ox-content/vite-plugin': 3.2.2
+  '@ox-content/vite-plugin-svelte': 3.2.2
   '@rsvelte/vite-plugin-svelte': 0.5.2
   '@tanstack/charts': 0.14.0
   '@types/bun': ^1.3.14

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,11 +7,11 @@ catalog:
   '@fontsource/jetbrains-mono': ^5.3.0
   '@fontsource/roboto-condensed': ^5.3.0
   '@iconify/json': ^2.2.510
-  '@ox-content/islands': 3.1.8
-  '@ox-content/napi': 3.1.8
-  '@ox-content/theme-color-kanagawa': 3.1.8
-  '@ox-content/vite-plugin': 3.1.8
-  '@ox-content/vite-plugin-svelte': 3.1.8
+  '@ox-content/islands': 3.2.1
+  '@ox-content/napi': 3.2.1
+  '@ox-content/theme-color-kanagawa': 3.2.1
+  '@ox-content/vite-plugin': 3.2.1
+  '@ox-content/vite-plugin-svelte': 3.2.1
   '@rsvelte/vite-plugin-svelte': 0.5.2
   '@tanstack/charts': 0.14.0
   '@types/bun': ^1.3.14

--- a/src/config/content.ts
+++ b/src/config/content.ts
@@ -1,3 +1,7 @@
+import type {
+	CollectionValidationContext,
+	CollectionValidationResult,
+} from '@ox-content/vite-plugin';
 import path from 'node:path';
 
 /** Shared root of the configured blog and showcase collections. */
@@ -20,7 +24,7 @@ export const SHOWCASE_DIRECTORY = path.join(CONTENT_DIRECTORY, 'works/showcase')
  *
  * The blog collection is mounted below `/blog`, so every source must declare
  * the route explicitly; keeping the shape here stops the new-post command and
- * the collection test from drifting apart.
+ * the collection validator from drifting apart.
  *
  * @param slug - Directory name of the post, e.g. `2026-09-09-revenge-ja`.
  * @returns The permalink, e.g. `/blog/2026-09-09-revenge-ja`.
@@ -29,4 +33,55 @@ export const SHOWCASE_DIRECTORY = path.join(CONTENT_DIRECTORY, 'works/showcase')
  */
 export function blogPermalink(slug: string): string {
 	return `/blog/${slug}`;
+}
+
+/**
+ * Rejects a blog document whose `permalink` disagrees with its source layout.
+ *
+ * Ox Content routes a post entirely from this key, so a missing or stale value
+ * publishes it under the wrong URL. `path` is the route the file tree already
+ * implies, before permalink rewrites, so it is what the key has to repeat.
+ *
+ * @param context - Collection validation context supplied by Ox Content.
+ * @returns A diagnostic message, or nothing when the document is valid.
+ * @example
+ * validateBlogPermalink({ path: '/blog/post', frontmatter: {} });
+ * // 'expected permalink /blog/post, found (missing)'
+ */
+export function validateBlogPermalink({
+	path: route,
+	frontmatter,
+}: Pick<CollectionValidationContext, 'path' | 'frontmatter'>): CollectionValidationResult {
+	if (frontmatter.permalink === route) return;
+	// An absent key and a malformed value need different fixes, so say which it is.
+	const found = 'permalink' in frontmatter ? JSON.stringify(frontmatter.permalink) : '(missing)';
+	return `expected permalink ${route}, found ${found}`;
+}
+
+if (import.meta.vitest != null) {
+	test.each([
+		{ name: 'a matching permalink', frontmatter: { permalink: '/blog/post' }, expected: undefined },
+		{
+			name: 'an absent key',
+			frontmatter: { title: 'Post' },
+			expected: 'expected permalink /blog/post, found (missing)',
+		},
+		{
+			name: 'a stale route',
+			frontmatter: { permalink: '/blog/typo' },
+			expected: 'expected permalink /blog/post, found "/blog/typo"',
+		},
+		{
+			name: 'a non-string value',
+			frontmatter: { permalink: 42 },
+			expected: 'expected permalink /blog/post, found 42',
+		},
+		{
+			name: 'an explicitly null value',
+			frontmatter: { permalink: null },
+			expected: 'expected permalink /blog/post, found null',
+		},
+	] as const)('reports $name', ({ frontmatter, expected }) => {
+		expect(validateBlogPermalink({ path: '/blog/post', frontmatter })).toBe(expected);
+	});
 }

--- a/src/config/ox-content.ts
+++ b/src/config/ox-content.ts
@@ -3,7 +3,7 @@ import { SITE_NAME, SITE_ORIGIN } from './site.ts';
 import { REDIRECT_ROUTES } from './redirects.ts';
 import { OPEN_GRAPH_OPTIONS } from './open-graph.ts';
 import { OX_MARKDOWN_OPTIONS, twitterCacheDirectory, twitterMediaDirectory } from './markdown.ts';
-import { BLOG_SOURCE_PATTERNS, blogPermalink, SHOWCASE_SOURCE_PATTERN } from './content.ts';
+import { BLOG_SOURCE_PATTERNS, SHOWCASE_SOURCE_PATTERN, validateBlogPermalink } from './content.ts';
 import { BLOG_FEED_OPTIONS } from '../pages/blog/feed.ts';
 import { MEDIA_FEED_OPTIONS } from '../pages/works/media/feed.ts';
 
@@ -19,7 +19,11 @@ export const OX_CONTENT_BUILD_OPTIONS = {
 	srcDir: 'src/content',
 	outDir: 'dist',
 	collections: {
-		blog: { source: BLOG_SOURCE_PATTERNS.map((pattern) => `blog/${pattern}`), include: ['body'] },
+		blog: {
+			source: BLOG_SOURCE_PATTERNS.map((pattern) => `blog/${pattern}`),
+			include: ['body'],
+			validate: validateBlogPermalink,
+		},
 		showcase: { source: SHOWCASE_SOURCE_PATTERN, include: ['body'] },
 	},
 	docs: false,
@@ -96,22 +100,3 @@ export const OX_CONTENT_BUILD_OPTIONS = {
 		},
 	},
 } as const satisfies OxContentOptions;
-
-if (import.meta.vitest != null) {
-	test('mounts every blog source below the public blog route', async () => {
-		const [fs, path, tinyglobby] = await Promise.all([
-			import('node:fs/promises'),
-			import('node:path'),
-			import('tinyglobby'),
-		]);
-		const root = path.join(process.cwd(), 'src/content/blog');
-		const files = await tinyglobby.glob(BLOG_SOURCE_PATTERNS, { cwd: root });
-
-		for (const file of files) {
-			const slug = path.dirname(file);
-			expect(await fs.readFile(path.join(root, file), 'utf8')).toMatch(
-				`---\npermalink: ${blogPermalink(slug)}\n`,
-			);
-		}
-	});
-}


### PR DESCRIPTION
## Why

`permalink` drives blog routing entirely, so a missing or stale value publishes a post under the wrong URL — which is what broke #2147.

The only guard was a test in `src/config/ox-content.ts` that read the real `src/content/blog` directory. That conflated two different things: validating real content is the build's job, while a test should exercise logic against fixed inputs. It also ran nowhere near the build, so nothing checked content at the point it actually matters.

## What

Ox Content 3.2.2 adds a per-collection `validate` hook, so the rule is declared on the collection instead of reimplemented locally:

```ts
blog: {
  source: BLOG_SOURCE_PATTERNS.map((pattern) => `blog/${pattern}`),
  include: ['body'],
  validate: validateBlogPermalink,
},
```

- `validateBlogPermalink()` compares the declared `permalink` against the context's `path` — the route the file tree already implies, before permalink rewrites — and distinguishes an absent key from a malformed value.
- CI gains a `Validate Content` step running `oxct validate`, which executes the hooks without a full build.
- Bumps `@ox-content/*` 3.1.8 → 3.2.2.
- Removes the real-content test; the validator is covered as plain logic with a table of cases.

## Upstream

None of this existed when the PR was opened — an earlier revision carried a local Vite plugin as a stopgap, now deleted. The capability was requested and shipped upstream instead:

| issue | outcome |
| - | - |
| [#1406](https://github.com/ubugeeei-prod/ox-content/issues/1406) | the `validate` hook — shipped in 3.2.0 |
| [#1410](https://github.com/ubugeeei-prod/ox-content/issues/1410) | `binding-darwin-arm64@3.2.0` missing from npm — fixed |
| [#1412](https://github.com/ubugeeei-prod/ox-content/issues/1412) | 3.2.0 broke Svelte island SSR — fixed in 3.2.1 |
| [#1413](https://github.com/ubugeeei-prod/ox-content/issues/1413) | `oxct validate` — shipped in 3.2.2 |

## Review findings

All three from the earlier review are resolved:

1. **No CI coverage without a build step.** Fixed properly — `oxct validate` is now a CI step, so `ci` catches a bad permalink without paying for a full build.
2. **Non-string `permalink` reported as `(missing)`.** Fixed — reports `found 42` and `found null` distinctly from `found (missing)`.
3. **Dev server aborts on an invalid draft.** No longer a local choice; validation runs inside Ox Content's manifest generation.

## Verification

```
$ pnpm run validate:content        # clean
[ox-content] Collection validation passed for 77 documents in 2 collections.   # exit 0

$ pnpm run validate:content        # post with `permalink: 42`
[ox-content] Collection validation failed with 1 diagnostic.
- blog: blog/zz-gate/index.mdx (/blog/zz-gate): expected permalink /blog/zz-gate, found 42   # exit 1
```

- `pnpm build` — 442 output files, and fails with the same diagnostic on a bad post
- `pnpm test` — 46 passed
- `pnpm check` — no lint/type errors, svelte-check 1156 files 0 errors